### PR TITLE
fix(python): login again with email and password

### DIFF
--- a/python/dataverse_sdk/apis/backend.py
+++ b/python/dataverse_sdk/apis/backend.py
@@ -80,7 +80,7 @@ class BackendAPI:
         if resp.status_code == 401 or resp.status_code == 403:
             logger.info(f"[{parent_func}] request forbidden.")
             logger.info(f"[{parent_func}] start to refresh access token.")
-            self.login()
+            self.login(email=self.email, password=self.password)
             logger.info(f"[{parent_func}] access token refreshed.")
             return self.send_request(
                 url=url,

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "dataverse-sdk"
-PACKAGE_VERSION = "0.3.1"
+PACKAGE_VERSION = "0.3.2"
 DESC = "Dataverse SDK For Python"
 with open("README.md", encoding="utf-8") as fh:
     long_description = fh.read()


### PR DESCRIPTION
## Purpose

<!-- Briefly describe the purpose of this PR -->
As title.

## Root Cause
```
2023-10-25T14:59:43+08:00   ERROR 2023-10-25 06:59:43,873 serializers 17 139844340149120 dataverse_project: Failed to get the project: BackendAPI.login() missing 2 required positional arguments: 'email' and 'password'
2023-10-25T14:50:48+08:00   ERROR 2023-10-25 06:50:46,449 log 17 139844340149120 Internal Server Error: /api/dataverse/26/option
2023-10-25T14:50:46+08:00   ERROR 2023-10-25 06:50:46,440 exceptions 17 139844340149120 Failed to get the project: BackendAPI.login() missing 2 required positional arguments: 'email' and 'password'
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/dataverse_sdk/client.py", line 242, in get_project
    project_data: dict = api.get_project(project_id=project_id)
  File "/usr/local/lib/python3.10/site-packages/dataverse_sdk/apis/backend.py", line 168, in get_project
    resp = self.send_request(
  File "/usr/local/lib/python3.10/site-packages/dataverse_sdk/apis/backend.py", line 83, in send_request
    self.login()
TypeError: BackendAPI.login() missing 2 required positional arguments: 'email' and 'password'
```

## What Changes?
- add input arguments for calling self.login()

## What to Check?
Could login as usual
