### PR TITLE
feat(python): be able to interact with multiple clients via the specified alias

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -29,16 +29,26 @@ Interaction with the Dataverse site starts with an instance of the `DataverseCli
 from dataverse_sdk import *
 from dataverse_sdk.connections import get_connection
 client = DataverseClient(
-    host=DataverseHost.PRODUCTION, email="XXX", password="***", alias="default"
+    host=DataverseHost.PRODUCTION, email="XXX", password="***", alias="default", force = False,
 )
 assert client is get_connection()
 
 # Should provide different alias if you are trying to connect to different workspaces
 client2 = DataverseClient(
-    host=DataverseHost.PRODUCTION, email="acount-2", password="***", alias="client2"
+    host=DataverseHost.PRODUCTION, email="account-2", password="***", alias="client2", force = False,
 )
 assert client2 is get_connection()
 ```
+
+* Input arguments:
+
+| Argument name      | Type/Options   | Default   | Description   |
+| :---                 |     :---    |     :---  |          :--- |
+| host        | str  | 	＊--    | the host url of the dataverse site    |
+| email  | str | ＊--  |  the email account of your dataverse workspace |
+| password  | str | ＊--  |  the password of your dataverse workspace  |
+| alias | str | 'default' |  the connection alias of your dataverse client |
+| force  | bool | False  |  whether force to replace the connection if the given alias exists |
 
 
 ## Key concepts

--- a/python/README.md
+++ b/python/README.md
@@ -29,7 +29,7 @@ Interaction with the Dataverse site starts with an instance of the `DataverseCli
 from dataverse_sdk import *
 from dataverse_sdk.connections import get_connection
 client = DataverseClient(
-    host=DataverseHost.PRODUCTION, email="XXX", password="***"
+    host=DataverseHost.PRODUCTION, email="XXX", password="***", alias="default"
 )
 assert client is get_connection()
 ```

--- a/python/README.md
+++ b/python/README.md
@@ -148,10 +148,10 @@ project = client.create_project(name="Sample project", ontology=ontology, sensor
 
 ### Get Project
 
-The `get_proejct` method retrieves the project from the connected site. The `project_id` parameter is the unique interger ID of the project, not its "name" property.
+The `get_proejct` method retrieves the project from the connected site. The `project_id` parameter is the unique integer ID of the project, not its "name" property.
 
 ```Python
-project = client.get_project(project_id= 1)
+project = client.get_project(project_id= 1, client_alias=client.alias) # if client_alias is not provided, we'll get it from client
 ```
 
 <br>
@@ -176,6 +176,7 @@ tag = {
                 ]
             }]}
 project_tag= ProjectTag(**tag)
+#should provided client_alias if calling from client
 client.add_project_tag(project_id = 10, project_tag=project_tag, client_alias=client.alias)
 #OR
 project.add_project_tag(project_tag=project_tag)
@@ -197,6 +198,7 @@ tag = {
                 ]
             }]}
 project_tag= ProjectTag(**tag)
+#should provided client_alias if calling from client
 client.edit_project_tag(project_id = 10, project_tag=project_tag, client_alias=client.alias)
 #OR
 project.edit_project_tag(project_tag=project_tag)
@@ -217,6 +219,7 @@ new_classes = [OntologyClass(name="obstruction",
                     "options": [{
                     "value": "static"}, {"value": "moving"
                     }]}])]
+#should provided client_alias if calling from client
 client.add_ontology_classes(project_id=24, ontology_classes=new_classes, client_alias=client.alias)
 #OR
 project.add_ontology_classes(ontology_classes=new_classes)
@@ -239,6 +242,7 @@ edit_classes = [OntologyClass(name="obstruction",
                     "option",
                     "options": [{
                     "value": "unknown"}]}])]
+#should provided client_alias if calling from client
 client.edit_ontology_classes(project_id=24, ontology_classes=edit_classes, client_alias=client.alias)
 #OR
 project.edit_ontology_classes(ontology_classes=edit_classes)

--- a/python/README.md
+++ b/python/README.md
@@ -1,5 +1,5 @@
 # Dataverse SDK For Python
-Dataverse is a MLOPs platform for assisting in data selection, data visualization and model training in comupter vision.
+Dataverse is a MLOPs platform for assisting in data selection, data visualization and model training in computer vision.
 Use Dataverse-SDK for Python to help you to interact with the Dataverse platform by Python. Currently, the library supports:
   - Create Project with your input ontology and sensors
   - Get Project by project-id
@@ -103,8 +103,8 @@ For project with lidar sensor, your should assign `pcd_type = OntologyPcdType.CU
 ```Python
 # 2) Create your sensor list with name / SensorType
 sensors = [
-    Sensor(name="camera_1", type=SensorType.CAMERA),
-    Sensor(name="lidar_1", type=SensorType.LIDAR),
+    Sensor(name="camera1", type=SensorType.CAMERA),
+    Sensor(name="lidar1", type=SensorType.LIDAR),
 ]
 
 # 3) Create your project tag attributes (Optional)
@@ -298,7 +298,7 @@ dataset = project.create_dataset(**dataset_data)
 
 ### Get Dataset
 
-The `get_dataset` method retrieves the dataset info from the connected site. The `dataset_id` parameter is the unique interger ID of the dataset, not its "name" property.
+The `get_dataset` method retrieves the dataset info from the connected site. The `dataset_id` parameter is the unique integer ID of the dataset, not its "name" property.
 
 ```Python
 dataset = client.get_dataset(dataset_id=5)

--- a/python/README.md
+++ b/python/README.md
@@ -32,6 +32,12 @@ client = DataverseClient(
     host=DataverseHost.PRODUCTION, email="XXX", password="***", alias="default"
 )
 assert client is get_connection()
+
+# Should provide different alias if you are trying to connect to different workspaces
+client2 = DataverseClient(
+    host=DataverseHost.PRODUCTION, email="acount-2", password="***", alias="client2"
+)
+assert client2 is get_connection()
 ```
 
 
@@ -170,7 +176,7 @@ tag = {
                 ]
             }]}
 project_tag= ProjectTag(**tag)
-client.add_project_tag(project_id = 10, project_tag=project_tag)
+client.add_project_tag(project_id = 10, project_tag=project_tag, client_alias=client.alias)
 #OR
 project.add_project_tag(project_tag=project_tag)
 ```
@@ -191,7 +197,7 @@ tag = {
                 ]
             }]}
 project_tag= ProjectTag(**tag)
-client.edit_project_tag(project_id = 10, project_tag=project_tag)
+client.edit_project_tag(project_id = 10, project_tag=project_tag, client_alias=client.alias)
 #OR
 project.edit_project_tag(project_tag=project_tag)
 ```
@@ -211,7 +217,7 @@ new_classes = [OntologyClass(name="obstruction",
                     "options": [{
                     "value": "static"}, {"value": "moving"
                     }]}])]
-client.add_ontology_classes(project_id=24, ontology_classes=new_classes)
+client.add_ontology_classes(project_id=24, ontology_classes=new_classes, client_alias=client.alias)
 #OR
 project.add_ontology_classes(ontology_classes=new_classes)
 ```
@@ -233,7 +239,7 @@ edit_classes = [OntologyClass(name="obstruction",
                     "option",
                     "options": [{
                     "value": "unknown"}]}])]
-client.edit_ontology_classes(project_id=24, ontology_classes=edit_classes)
+client.edit_ontology_classes(project_id=24, ontology_classes=edit_classes, client_alias=client.alias)
 #OR
 project.edit_ontology_classes(ontology_classes=edit_classes)
 ```
@@ -264,6 +270,7 @@ dataset_data = {
     "secret_access_key": "aws s3 secret access key"# only for private s3 bucket, don't need to assign it in case of public s3 bucket or azure data source
 }
 dataset = project.create_dataset(**dataset_data)
+
 ```
 
 * Input arguments for creating dataset from cloud storage:
@@ -310,7 +317,7 @@ The `list_models` method will list all the models in the given project
 
 ```Python
 #1
-models = client.list_models(project_id = 1)
+models = client.list_models(project_id = 1, client_alias=client.alias)
 #2
 project = client.get_project(project_id=1)
 models = project.list_models()
@@ -321,7 +328,7 @@ models = project.list_models()
 The `get_model` method will get the model detail info by the given model-id
 
 ```Python
-model = client.get_model(model_id=30)
+model = client.get_model(model_id=30, client_alias=client.alias)
 model = project.get_model(model_id=30)
 ```
 From the given model, we could get the label file / triton model file / onnx model file by the commands below.

--- a/python/dataverse_sdk/client.py
+++ b/python/dataverse_sdk/client.py
@@ -241,13 +241,14 @@ class DataverseClient:
             raise ClientConnectionError(f"Failed to get the project: {e}")
         return Project.create(project_data, client_alias=client_alias)
 
-    def get_project(self, project_id: int):
+    def get_project(self, project_id: int, client_alias: Optional[str] = None):
         """Get project detail by project-id
 
         Parameters
         ----------
         project_id : int
             project-id in db
+        client_alias: Optional[str], by default None (will reset to self.alias if it's not provided)
 
         Returns
         -------
@@ -259,9 +260,11 @@ class DataverseClient:
         ClientConnectionError
             raise exception if there is any error occurs when calling backend APIs.
         """
-        client = self.get_client(self.alias)
+        if client_alias is None:
+            client_alias = self.alias
+        client = self.get_client(client_alias)
         return self.get_client_project(
-            project_id=project_id, client=client, client_alias=self.alias
+            project_id=project_id, client=client, client_alias=client_alias
         )
 
     @staticmethod

--- a/python/dataverse_sdk/client.py
+++ b/python/dataverse_sdk/client.py
@@ -617,7 +617,7 @@ class DataverseClient:
         try:
             model_data: dict = api.get_ml_model(model_id=model_id)
         except Exception as e:
-            raise ClientConnectionError(f"Failed to get the dataset: {e}")
+            raise ClientConnectionError(f"Failed to get the model: {e}")
 
         if project is None:
             project = client.get_client_project(
@@ -762,7 +762,7 @@ class DataverseClient:
             logging.exception("Failed to get onnx model file")
             return False, save_path
 
-    def get_dataset(self, dataset_id: int):
+    def get_dataset(self, dataset_id: int, client_alias: Optional[str] = None):
         """Get dataset detail and status by id
 
         Parameters
@@ -774,15 +774,18 @@ class DataverseClient:
         -------
         Dataset
             dataset basemodel from host response for client usage
+        client_alias: Optional[str], by default None (will reset to self.alias if it's not provided)
 
         Raises
         ------
         ClientConnectionError
             raise exception if there is any error occurs when calling backend APIs.
         """
-
+        if client_alias is None:
+            client_alias = self.alias
+        client = self.get_client(client_alias)
         try:
-            dataset_data: dict = self._api_client.get_dataset(dataset_id=dataset_id)
+            dataset_data: dict = client._api_client.get_dataset(dataset_id=dataset_id)
         except Exception as e:
             raise ClientConnectionError(f"Failed to get the dataset: {e}")
 
@@ -791,7 +794,7 @@ class DataverseClient:
             Sensor.create(sensor_data) for sensor_data in dataset_data["sensors"]
         ]
         dataset_data.update({"project": project, "sensors": sensors})
-        return Dataset(**dataset_data, client_alias=self.alias)
+        return Dataset(**dataset_data, client_alias=client_alias)
 
     # TODO: required arguments for different DataSource
     @staticmethod

--- a/python/dataverse_sdk/client.py
+++ b/python/dataverse_sdk/client.py
@@ -735,9 +735,9 @@ class DataverseClient:
         """
         if client_alias is None:
             client_alias = self.alias
-        client = self.get_client(client_alias)
+        api, client_alias = DataverseClient._get_api_client(client_alias=client_alias)
         try:
-            dataset_data: dict = client._api_client.get_dataset(dataset_id=dataset_id)
+            dataset_data: dict = api.get_dataset(dataset_id=dataset_id)
         except Exception as e:
             raise ClientConnectionError(f"Failed to get the dataset: {e}")
 

--- a/python/dataverse_sdk/client.py
+++ b/python/dataverse_sdk/client.py
@@ -90,6 +90,21 @@ class DataverseClient:
             raise ClientConnectionError(f"Failed to initialize the api client: {e}")
 
     @staticmethod
+    def _get_api_client(
+        client: Optional["DataverseClient"] = None, client_alias: Optional[str] = None
+    ):
+        if client is None:
+            if client_alias is None:
+                raise ValueError(
+                    "Please provide the DataverseClient or the connection alias!"
+                )
+            client = DataverseClient.get_client(client_alias)
+        else:
+            client_alias = client.alias
+        api = client._api_client
+        return api, client_alias
+
+    @staticmethod
     def get_client(alias: str = "default") -> "DataverseClient":
         try:
             return get_connection(alias)
@@ -226,15 +241,9 @@ class DataverseClient:
         client: Optional["DataverseClient"] = None,
         client_alias: Optional[str] = None,
     ):
-        if client is None:
-            if client_alias is None:
-                raise ValueError(
-                    "Please provide the DataverseClient or the connection alias!"
-                )
-            client = cls.get_client(client_alias)
-        else:
-            client_alias = client.alias
-        api = client._api_client
+        api, client_alias = DataverseClient._get_api_client(
+            client=client, client_alias=client_alias
+        )
         try:
             project_data: dict = api.get_project(project_id=project_id)
         except Exception as e:
@@ -262,10 +271,7 @@ class DataverseClient:
         """
         if client_alias is None:
             client_alias = self.alias
-        client = self.get_client(client_alias)
-        return self.get_client_project(
-            project_id=project_id, client=client, client_alias=client_alias
-        )
+        return self.get_client_project(project_id=project_id, client_alias=client_alias)
 
     @staticmethod
     def add_project_tag(
@@ -296,18 +302,12 @@ class DataverseClient:
         ClientConnectionError
             API error when creating new project tag
         """
-        if client is None:
-            if client_alias is None:
-                raise ValueError(
-                    "Please provide the DataverseClient or the connection alias!"
-                )
-            client = DataverseClient.get_client(client_alias)
-        else:
-            client_alias = client.alias
-        api = client._api_client
+        api, client_alias = DataverseClient._get_api_client(
+            client=client, client_alias=client_alias
+        )
         if project is None:
             project = DataverseClient.get_client_project(
-                project_id=project_id, client=client, client_alias=client_alias
+                project_id=project_id, client_alias=client_alias
             )
 
         raw_project_tag: dict = project_tag.dict(exclude_none=True)
@@ -357,15 +357,9 @@ class DataverseClient:
             API error when editing project tag
         """
 
-        if client is None:
-            if client_alias is None:
-                raise ValueError(
-                    "Please provide the DataverseClient or the connection alias!"
-                )
-            client = DataverseClient.get_client(client_alias)
-        else:
-            client_alias = client.alias
-        api = client._api_client
+        api, client_alias = DataverseClient._get_api_client(
+            client=client, client_alias=client_alias
+        )
         if project is None:
             project = DataverseClient.get_client_project(
                 project_id=project_id, client=client, client_alias=client_alias
@@ -417,15 +411,9 @@ class DataverseClient:
         ClientConnectionError
             API error when creating new ontology class
         """
-        if client is None:
-            if client_alias is None:
-                raise ValueError(
-                    "Please provide the DataverseClient or the connection alias!"
-                )
-            client = DataverseClient.get_client(client_alias)
-        else:
-            client_alias = client.alias
-        api = client._api_client
+        api, client_alias = DataverseClient._get_api_client(
+            client=client, client_alias=client_alias
+        )
         if project is None:
             project = DataverseClient.get_client_project(
                 project_id=project_id, client=client, client_alias=client_alias
@@ -485,15 +473,9 @@ class DataverseClient:
         ClientConnectionError
             API error when editing ontology classes
         """
-        if client is None:
-            if client_alias is None:
-                raise ValueError(
-                    "Please provide the DataverseClient or the connection alias!"
-                )
-            client = DataverseClient.get_client(client_alias)
-        else:
-            client_alias = client.alias
-        api = client._api_client
+        api, client_alias = DataverseClient._get_api_client(
+            client=client, client_alias=client_alias
+        )
         if project is None:
             project = DataverseClient.get_client_project(
                 project_id=project_id, client=client, client_alias=client_alias
@@ -547,15 +529,9 @@ class DataverseClient:
         ClientConnectionError
             raise exception if there is any error occurs when calling backend APIs.
         """
-        if client is None:
-            if client_alias is None:
-                raise ValueError(
-                    "Please provide the DataverseClient or the connection alias!"
-                )
-            client = DataverseClient.get_client(client_alias)
-        else:
-            client_alias = client.alias
-        api = client._api_client
+        api, client_alias = DataverseClient._get_api_client(
+            client=client, client_alias=client_alias
+        )
         try:
             model_list: list = api.list_ml_models(project_id=project_id)
         except Exception as e:
@@ -605,22 +581,16 @@ class DataverseClient:
         ClientConnectionError
             raise exception if there is any error occurs when calling backend APIs.
         """
-        if client is None:
-            if client_alias is None:
-                raise ValueError(
-                    "Please provide the DataverseClient or the connection alias!"
-                )
-            client = DataverseClient.get_client(client_alias)
-        else:
-            client_alias = client.alias
-        api = client._api_client
+        api, client_alias = DataverseClient._get_api_client(
+            client=client, client_alias=client_alias
+        )
         try:
             model_data: dict = api.get_ml_model(model_id=model_id)
         except Exception as e:
             raise ClientConnectionError(f"Failed to get the model: {e}")
 
         if project is None:
-            project = client.get_client_project(
+            project = DataverseClient.get_client_project(
                 project_id=model_data["project"]["id"],
                 client=client,
                 client_alias=client_alias,
@@ -655,15 +625,9 @@ class DataverseClient:
             the first item means whether the download success or not
             the second item shows the save_path
         """
-        if client is None:
-            if client_alias is None:
-                raise ValueError(
-                    "Please provide the DataverseClient or the connection alias!"
-                )
-            client = DataverseClient.get_client(client_alias)
-        else:
-            client_alias = client.alias
-        api = client._api_client
+        api, client_alias = DataverseClient._get_api_client(
+            client=client, client_alias=client_alias
+        )
         try:
             resp = api.get_ml_model_labels(model_id=model_id, timeout=timeout)
             download_file_from_response(response=resp, save_path=save_path)
@@ -699,15 +663,9 @@ class DataverseClient:
             the first item means whether the download success or not
             the second item shows the save_path
         """
-        if client is None:
-            if client_alias is None:
-                raise ValueError(
-                    "Please provide the DataverseClient or the connection alias!"
-                )
-            client = DataverseClient.get_client(client_alias)
-        else:
-            client_alias = client.alias
-        api = client._api_client
+        api, client_alias = DataverseClient._get_api_client(
+            client=client, client_alias=client_alias
+        )
         try:
             resp = api.get_ml_model_file(model_id=model_id, timeout=timeout)
             download_file_from_response(response=resp, save_path=save_path)
@@ -743,15 +701,9 @@ class DataverseClient:
             the first item means whether the download success or not
             the second item shows the save_path
         """
-        if client is None:
-            if client_alias is None:
-                raise ValueError(
-                    "Please provide the DataverseClient or the connection alias!"
-                )
-            client = DataverseClient.get_client(client_alias)
-        else:
-            client_alias = client.alias
-        api = client._api_client
+        api, client_alias = DataverseClient._get_api_client(
+            client=client, client_alias=client_alias
+        )
         try:
             resp = api.get_ml_model_file(
                 model_id=model_id, timeout=timeout, model_format="onnx"
@@ -891,14 +843,9 @@ class DataverseClient:
             raise ValueError(
                 "Annotated data should provide at least one annotation folder name (groundtruth or model_name)"
             )
-        if client is None:
-            if client_alias is None:
-                raise ValueError(
-                    "Please provide the dataverse client or the connection alias!"
-                )
-            client = DataverseClient.get_client(client_alias)
-        else:
-            client_alias = client.alias
+        api, client_alias = DataverseClient._get_api_client(
+            client=client, client_alias=client_alias
+        )
 
         sensor_ids = [sensor.id for sensor in sensors]
         project_id = project.id
@@ -928,8 +875,6 @@ class DataverseClient:
             raise ValidationError(
                 f"Something wrong when composing the final dataset data: {e}"
             )
-
-        api = client._api_client
 
         try:
             dataset_data = api.create_dataset(**raw_dataset_data)

--- a/python/dataverse_sdk/client.py
+++ b/python/dataverse_sdk/client.py
@@ -92,7 +92,7 @@ class DataverseClient:
     @staticmethod
     def _get_api_client(
         client: Optional["DataverseClient"] = None, client_alias: Optional[str] = None
-    ):
+    ) -> tuple[BackendAPI, str]:
         if client is None:
             if client_alias is None:
                 raise ValueError(

--- a/python/dataverse_sdk/connections.py
+++ b/python/dataverse_sdk/connections.py
@@ -10,17 +10,23 @@ class Connections:
     def __init__(self):
         self._conns = {}
 
-    def add_connection(self, alias, conn):
+    def add_connection(self, alias, conn, force=True):
         """
         Add a connection object, it will be passed through as-is.
         """
+        if force is False:
+            if alias in self._conns:
+                raise ValueError(f"The connection alias, {alias}, is already exist")
         self._conns[alias] = conn
 
-    def create_connection(self, alias="default", **kwargs):
+    def create_connection(self, alias="default", force=True, **kwargs):
         """
         Construct an instance of ``dataverse_sdk.DataverseClient`` and register
         it under given alias.
         """
+        if force is False:
+            if alias in self._conns:
+                raise ValueError(f"The connection alias, {alias}, is already exist")
         from .client import DataverseClient
 
         conn = self._conns[alias] = DataverseClient(**kwargs)

--- a/python/dataverse_sdk/schemas/client.py
+++ b/python/dataverse_sdk/schemas/client.py
@@ -115,6 +115,7 @@ class Ontology(BaseModel):
 class Project(BaseModel):
     id: int
     name: str
+    client_alias: str
     description: Optional[str] = None
     ego_car: Optional[str] = None
     ontology: Ontology
@@ -122,7 +123,7 @@ class Project(BaseModel):
     project_tag: Optional[ProjectTag] = None
 
     @classmethod
-    def create(cls, project_data: dict) -> "Project":
+    def create(cls, project_data: dict, client_alias: str) -> "Project":
         ontology = Ontology.create(project_data["ontology"])
         # TODO modify the condition if list projects results with list fields
         if project_data.get("sensors") is None:
@@ -142,13 +143,17 @@ class Project(BaseModel):
             ontology=ontology,
             sensors=sensors,
             project_tag=project_tag,
+            client_alias=client_alias,
         )
 
     def add_project_tag(self, project_tag: ProjectTag):
         from ..client import DataverseClient
 
         project = DataverseClient.add_project_tag(
-            project_tag=project_tag, project=self, project_id=self.id
+            project_tag=project_tag,
+            project=self,
+            project_id=self.id,
+            client_alias=self.client_alias,
         )
         return project
 
@@ -156,7 +161,10 @@ class Project(BaseModel):
         from ..client import DataverseClient
 
         project = DataverseClient.edit_project_tag(
-            project_tag=project_tag, project=self, project_id=self.id
+            project_tag=project_tag,
+            project=self,
+            project_id=self.id,
+            client_alias=self.client_alias,
         )
         return project
 
@@ -164,7 +172,10 @@ class Project(BaseModel):
         from ..client import DataverseClient
 
         project = DataverseClient.add_ontology_classes(
-            ontology_classes=ontology_classes, project=self, project_id=self.id
+            ontology_classes=ontology_classes,
+            project=self,
+            project_id=self.id,
+            client_alias=self.client_alias,
         )
         return project
 
@@ -175,13 +186,16 @@ class Project(BaseModel):
             ontology_classes=ontology_classes,
             project=self,
             project_id=self.id,
+            client_alias=self.client_alias,
         )
         return project
 
     def list_models(self) -> list:
         from ..client import DataverseClient
 
-        model_list: list = DataverseClient.list_models(project_id=self.id, project=self)
+        model_list: list = DataverseClient.list_models(
+            project_id=self.id, project=self, client_alias=self.client_alias
+        )
         return model_list
 
     def get_model(self, model_id: int):
@@ -208,7 +222,7 @@ class Project(BaseModel):
         render_pcd: bool = False,
         description: Optional[str] = None,
         access_key_id: Optional[str] = None,
-        secret_access_key:Optional[str] = None,
+        secret_access_key: Optional[str] = None,
         **kwargs,
     ):
         """Create Dataset From project itself
@@ -286,6 +300,7 @@ class Project(BaseModel):
             description=description,
             access_key_id=access_key_id,
             secret_access_key=secret_access_key,
+            client_alias=self.client_alias,
             **kwargs,
         )
         return dataset_output
@@ -309,6 +324,7 @@ class Dataset(BaseModel):
     created_by: Optional[int] = None
     container_name: Optional[str] = None
     storage_url: Optional[str] = None
+    client_alias: Optional[str] = None
 
     class Config:
         extra = "allow"
@@ -317,6 +333,7 @@ class Dataset(BaseModel):
 class MLModel(BaseModel):
     id: Optional[int] = None
     name: str
+    client_alias: str
     updated_at: str
     project: Project
     classes: list
@@ -327,7 +344,7 @@ class MLModel(BaseModel):
         extra = "allow"
 
     @classmethod
-    def create(cls, model_data: dict) -> "MLModel":
+    def create(cls, model_data: dict, client_alias: str) -> "MLModel":
         if isinstance(model_data["classes"][0], dict):
             target_class_id = {
                 ontology_class["id"] for ontology_class in model_data["classes"]
@@ -339,7 +356,7 @@ class MLModel(BaseModel):
 
         if model_data["project"] is None:
             project = DataverseClient.get_project(
-                project_id=model_data["project"]["id"]
+                project_id=model_data["project"]["id"], client_alias=client_alias
             )
         else:
             project = model_data["project"]
@@ -356,6 +373,7 @@ class MLModel(BaseModel):
             classes=classes,
             updated_at=model_data["updated_at"],
             triton_model_name=model_data["triton_model_name"],
+            client_alias=client_alias,
         )
 
     def get_label_file(
@@ -364,7 +382,10 @@ class MLModel(BaseModel):
         from ..client import DataverseClient
 
         return DataverseClient.get_label_file(
-            model_id=self.id, save_path=save_path, timeout=timeout
+            model_id=self.id,
+            save_path=save_path,
+            timeout=timeout,
+            client_alias=self.client_alias,
         )
 
     def get_triton_model_file(
@@ -373,7 +394,10 @@ class MLModel(BaseModel):
         from ..client import DataverseClient
 
         return DataverseClient.get_triton_model_file(
-            model_id=self.id, save_path=save_path, timeout=timeout
+            model_id=self.id,
+            save_path=save_path,
+            timeout=timeout,
+            client_alias=self.client_alias,
         )
 
     def get_onnx_model_file(
@@ -382,5 +406,8 @@ class MLModel(BaseModel):
         from ..client import DataverseClient
 
         return DataverseClient.get_onnx_model_file(
-            model_id=self.id, save_path=save_path, timeout=timeout
+            model_id=self.id,
+            save_path=save_path,
+            timeout=timeout,
+            client_alias=self.client_alias,
         )

--- a/python/dataverse_sdk/schemas/client.py
+++ b/python/dataverse_sdk/schemas/client.py
@@ -201,7 +201,9 @@ class Project(BaseModel):
     def get_model(self, model_id: int):
         from ..client import DataverseClient
 
-        model_data = DataverseClient.get_model(model_id=model_id, project=self)
+        model_data = DataverseClient.get_model(
+            model_id=model_id, project=self, client_alias=self.client_alias
+        )
         return model_data
 
     def create_dataset(

--- a/python/dataverse_sdk/schemas/client.py
+++ b/python/dataverse_sdk/schemas/client.py
@@ -355,7 +355,7 @@ class MLModel(BaseModel):
         from ..client import DataverseClient
 
         if model_data["project"] is None:
-            project = DataverseClient.get_project(
+            project = DataverseClient.get_client_project(
                 project_id=model_data["project"]["id"], client_alias=client_alias
             )
         else:

--- a/python/dataverse_sdk/schemas/common.py
+++ b/python/dataverse_sdk/schemas/common.py
@@ -51,3 +51,4 @@ class DataSource(str, Enum, metaclass=BaseEnumMeta):
     Azure = "azure"
     AWS = "aws"
     SDK = "sdk"
+    LOCAL = "local"

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "dataverse-sdk"
-PACKAGE_VERSION = "1.0.0"
+PACKAGE_VERSION = "1.1.0"
 DESC = "Dataverse SDK For Python"
 with open("README.md", encoding="utf-8") as fh:
     long_description = fh.read()


### PR DESCRIPTION
## Purpose

<!-- Fill the task or bug ID in azure board AB#{ID} -->
- [AB#18314](https://dev.azure.com/linkerengineer/87361b6b-4b8a-4d65-8243-96cf1163a72f/_workitems/edit/18314)

## Root Cause
We use ` DataverseClient.get_client()` to get the "default " client and can not get the client with other alias.

## What Changes?
- Add `force` argument in `add_connection` to identify whether to replace the client when provide alias exists.
- Add `client_alias` argument when creating Project/Dataset/MLModel.
- Adjusting get_project function and add `get_client_project` function.
- Add `client_alias` argument and related checking for getting client in the function of DataverseClient.
- Add `client_alias` argument for all related functions in `schemas/client.py`
- little fix the schema of DataSource and related checking for create_dataset


## What to Check?
- The SDK could work normally for getting data from multiple workspace
<img width="786" alt="image" src="https://github.com/linkervision/dataverse-sdk/assets/55373569/bd02a420-f282-40b6-9ea4-8572bcd83687">



