### PR TITLE
fix(sdk): update ontology image type schema with instance_segmentation

### DIFF
--- a/python/dataverse_sdk/schemas/common.py
+++ b/python/dataverse_sdk/schemas/common.py
@@ -13,6 +13,7 @@ class AttributeType(str, Enum, metaclass=BaseEnumMeta):
 class OntologyImageType(str, Enum, metaclass=BaseEnumMeta):
     _2D_BOUNDING_BOX = "2d_bounding_box"
     SEMANTIC_SEGMENTATION = "semantic_segmentation"
+    INSTANCE_SEGMENTATION = "instance_segmentation"
     CLASSIFICATION = "classification"
     POINT = "point"
     POLYGON = "polygon"

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "dataverse-sdk"
-PACKAGE_VERSION = "1.2.0"
+PACKAGE_VERSION = "1.2.1"
 DESC = "Dataverse SDK For Python"
 with open("README.md", encoding="utf-8") as fh:
     long_description = fh.read()


### PR DESCRIPTION
## Purpose

<!-- Briefly describe the purpose of this PR -->
As title.

<!-- Fill the task or bug ID in azure board AB#{ID} -->
- [AB#20513](https://dev.azure.com/linkerengineer/87361b6b-4b8a-4d65-8243-96cf1163a72f/_workitems/edit/20513)

## Root Cause

<!-- If the PR is bug fix, please provide the root cause of the bug -->
- instance_segmentation is not added in the basemodel (Projects with instance_segmentation will get errors.)

## What Changes?

<!-- For new feature is what you add and how to use it, for the bug is how to fix it. -->
- Add instance_segmentation in the OntologyImageType basemodel.

## What to Check?

<!-- Describe steps to verify the functions of this PR -->
- client.list_projects() could work.
<img width="669" alt="image" src="https://github.com/linkervision/dataverse-sdk/assets/55373569/af148015-bbea-48a3-bfee-26bb21993dc5">

