### PR TITLE
fix(python): add slash in get-project api

### DIFF
--- a/python/dataverse_sdk/apis/backend.py
+++ b/python/dataverse_sdk/apis/backend.py
@@ -184,7 +184,7 @@ class BackendAPI:
 
     def get_project(self, project_id) -> dict:
         resp = self.send_request(
-            url=f"{self.host}/api/projects/{project_id}",
+            url=f"{self.host}/api/projects/{project_id}/",
             method="get",
             headers=self.headers,
         )

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "dataverse-sdk"
-PACKAGE_VERSION = "1.3.0"
+PACKAGE_VERSION = "1.3.1"
 DESC = "Dataverse SDK For Python"
 with open("README.md", encoding="utf-8") as fh:
     long_description = fh.read()


### PR DESCRIPTION
## Purpose

<!-- Briefly describe the purpose of this PR -->
As title.

<!-- Fill the task or bug ID in azure board AB#{ID} -->
- [AB#20685](https://dev.azure.com/linkerengineer/87361b6b-4b8a-4d65-8243-96cf1163a72f/_workitems/edit/20685)

## Root Cause

<!-- If the PR is bug fix, please provide the root cause of the bug -->
- Missing slash

## What Changes?

<!-- For new feature is what you add and how to use it, for the bug is how to fix it. -->
- Add slash for get project api

## What to Check?
-The get project api could works on staging site.
<img width="478" alt="image" src="https://github.com/linkervision/dataverse-sdk/assets/55373569/1772cc33-66bf-44ea-946d-acae89c1dda0">

