### PR TITLE
feat(python): add functions for updating alias of ontology and getting model convert records

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -404,11 +404,11 @@ The `get_model` method will get the model detail info by the given model-id
 model = client.get_model(model_id=30, client_alias=client.alias)
 model = project.get_model(model_id=30)
 ```
-From the given model, we could get the label file / triton model file / onnx model file by the commands below.
+From the given model, we could get the model convert records as below
 ```Python
-status, label_file_path = model.get_label_file(save_path="./labels.txt", timeout=6000)
-status, triton_model_path = model.get_triton_model_file(save_path="./model.zip", timeout=6000)
-status, onnx_model_path = model.get_onnx_model_file(save_path="./model.onnx", timeout=6000)
+model_record = client.get_convert_record(convert_record_id=1, client_alias=client.alias)
+OR
+model_record = model.get_convert_record(convert_record_id=1)
 ```
 <br>
 

--- a/python/README.md
+++ b/python/README.md
@@ -275,6 +275,21 @@ client.edit_ontology_classes(project_id=24, ontology_classes=edit_classes, clien
 project.edit_ontology_classes(ontology_classes=edit_classes)
 ```
 
+
+#### Update Ontology Alias
+
+1. Get the csv file of alias map for your project
+```Python
+client.generate_alias_map(project_id=123, alias_file_path="./alias.csv")
+```
+
+2. Fill the alias in the csv file and save (DO NOT modify other fields)
+
+3. Update alias for your project with the alias file path
+```Python
+client.update_alias(project_id=123, alias_file_path= "/Users/Downloads/alias.csv" )
+```
+
 <br>
 
 ### Create Dataset

--- a/python/README.md
+++ b/python/README.md
@@ -64,12 +64,14 @@ Once you've initialized a DataverseClient, you can interact with Dataverse from 
 
 ## Examples
 
-The following sections provide examples for the most common DataVerse tasksm including:
+The following sections provide examples for the most common DataVerse tasks including:
 
 * [Get User](#get-user)
 * [List Projects](#list-projects)
 * [Create Project](#create-project)
 * [Get Project](#get-project)
+* [Edit Project](#edit-project)
+* [Update Alias](#update-ontology-alias)
 * [Create Dataset](#create-dataset)
 * [Get Dataset](#get-dataset)
 * [List Models](#list-models)
@@ -276,7 +278,7 @@ project.edit_ontology_classes(ontology_classes=edit_classes)
 ```
 
 
-#### Update Ontology Alias
+### Update Ontology Alias
 
 1. Get the csv file of alias map for your project
 ```Python

--- a/python/dataverse_sdk/apis/backend.py
+++ b/python/dataverse_sdk/apis/backend.py
@@ -234,15 +234,6 @@ class BackendAPI:
         )
         return resp.json()
 
-    def list_convert_records(self, ml_model_id: int, **kwargs) -> list:
-        kwargs["project"] = ml_model_id
-        resp = self.send_request(
-            url=f"{self.host}/api/convert_records/?{urlencode(kwargs)}",
-            method="get",
-            headers=self.headers,
-        )
-        return resp.json()["results"]
-
     def get_convert_model_labels(
         self, convert_record_id: int, timeout: int = 3000
     ) -> requests.models.Response:

--- a/python/dataverse_sdk/apis/backend.py
+++ b/python/dataverse_sdk/apis/backend.py
@@ -226,6 +226,14 @@ class BackendAPI:
         )
         return resp.json()
 
+    def get_convert_record(self, convert_record_id: int) -> dict:
+        resp = self.send_request(
+            url=f"{self.host}/api/convert_record/{convert_record_id}/",
+            method="get",
+            headers=self.headers,
+        )
+        return resp.json()
+
     def get_ml_model_labels(
         self, model_id: int, timeout: int = 3000
     ) -> requests.models.Response:

--- a/python/dataverse_sdk/apis/backend.py
+++ b/python/dataverse_sdk/apis/backend.py
@@ -73,7 +73,6 @@ class BackendAPI:
         except (requests.exceptions.RequestException, Exception) as e:
             logger.error(f"Unexpected exception, err: {repr(e)}")
             raise
-
         if resp.status_code in (401, 403, 404):
             logger.exception(f"[{parent_func}] request forbidden.")
             raise DataverseExceptionBase(status_code=resp.status_code, **resp.json())
@@ -191,6 +190,19 @@ class BackendAPI:
             headers=self.headers,
         )
         return resp.json()["results"]
+
+    def update_alias(
+        self,
+        project_id: int,
+        alias_list: list,
+    ) -> dict:
+        resp = self.send_request(
+            url=f"{self.host}/api/projects/{project_id}/bulk-upsert-alias/",
+            method="post",
+            headers=self.headers,
+            data=alias_list,
+        )
+        return resp.json()
 
     def list_ml_models(self, project_id: int, type: str = "trained", **kwargs) -> list:
         kwargs["project"] = project_id

--- a/python/dataverse_sdk/apis/backend.py
+++ b/python/dataverse_sdk/apis/backend.py
@@ -234,11 +234,11 @@ class BackendAPI:
         )
         return resp.json()
 
-    def get_ml_model_labels(
-        self, model_id: int, timeout: int = 3000
+    def get_convert_model_labels(
+        self, convert_record_id: int, timeout: int = 3000
     ) -> requests.models.Response:
         resp = self.send_request(
-            url=f"{self.host}/api/ml_models/{model_id}/labels/",
+            url=f"{self.host}/api/convert_record/{convert_record_id}/label/",
             method="get",
             headers=self.headers,
             stream=True,
@@ -246,14 +246,22 @@ class BackendAPI:
         )
         return resp
 
-    def get_ml_model_file(
-        self, model_id: int, timeout: int = 3000, model_format: str = "triton", **kwargs
+    def get_convert_model_file(
+        self,
+        convert_record_id: int,
+        timeout: int = 3000,
+        triton_format: bool = True,
+        permission: str = "",
+        **kwargs,
     ) -> requests.models.Response:
-        kwargs["model_format"] = model_format
+        headers = self.headers.copy()
+        kwargs["triton"] = triton_format
+        if permission:
+            headers["X-Request-Source"] = permission
         resp = self.send_request(
-            url=f"{self.host}/api/ml_models/{model_id}/model/?{urlencode(kwargs)}",
+            url=f"{self.host}/api/convert_record/{convert_record_id}/model-observ/?{urlencode(kwargs)}",
             method="get",
-            headers=self.headers,
+            headers=headers,
             stream=True,
             timeout=timeout,
         )

--- a/python/dataverse_sdk/apis/backend.py
+++ b/python/dataverse_sdk/apis/backend.py
@@ -234,6 +234,15 @@ class BackendAPI:
         )
         return resp.json()
 
+    def list_convert_records(self, ml_model_id: int, **kwargs) -> list:
+        kwargs["project"] = ml_model_id
+        resp = self.send_request(
+            url=f"{self.host}/api/convert_records/?{urlencode(kwargs)}",
+            method="get",
+            headers=self.headers,
+        )
+        return resp.json()["results"]
+
     def get_convert_model_labels(
         self, convert_record_id: int, timeout: int = 3000
     ) -> requests.models.Response:

--- a/python/dataverse_sdk/apis/backend.py
+++ b/python/dataverse_sdk/apis/backend.py
@@ -81,6 +81,10 @@ class BackendAPI:
             logger.exception(f"[{parent_func}] got bad request")
             raise DataverseExceptionBase(status_code=resp.status_code, **resp.json())
 
+        if resp.status_code == 500:
+            logger.exception(f"[{parent_func}] got api error")
+            raise DataverseExceptionBase(status_code=resp.status_code)
+
         if not 200 <= resp.status_code <= 299:
             raise DataverseExceptionBase(status_code=resp.status_code, **resp.json())
         return resp
@@ -200,9 +204,9 @@ class BackendAPI:
             url=f"{self.host}/api/projects/{project_id}/bulk-upsert-alias/",
             method="post",
             headers=self.headers,
-            data=alias_list,
+            json=alias_list,
         )
-        return resp.json()
+        return resp
 
     def list_ml_models(self, project_id: int, type: str = "trained", **kwargs) -> list:
         kwargs["project"] = project_id

--- a/python/dataverse_sdk/client.py
+++ b/python/dataverse_sdk/client.py
@@ -307,6 +307,20 @@ class DataverseClient:
             client_alias = self.alias
         return self.get_client_project(project_id=project_id, client_alias=client_alias)
 
+    def update_alias(self, project_id: int, alias_list: list):
+        try:
+            resp: dict = self._api_client.update_alias(
+                project_id=project_id, alias_list=alias_list
+            )
+        except DataverseExceptionBase as api_error:
+            logging.exception(
+                f"Got api error from Dataverse: {api_error.detail}, {api_error.error}"
+            )
+            raise
+        except Exception as e:
+            raise ClientConnectionError(f"Failed to edit the project alias: {e}")
+        return resp
+
     @staticmethod
     def add_project_tag(
         project_id: int,

--- a/python/dataverse_sdk/client.py
+++ b/python/dataverse_sdk/client.py
@@ -776,17 +776,14 @@ class DataverseClient:
         convert_record_id: int,
         client: Optional["DataverseClient"] = None,
         client_alias: Optional[str] = None,
-    ):
-        """_summary_
+    ) -> ConvertRecord:
+        """Get model convert record
 
         Parameters
         ----------
         convert_record_id : int
-            _description_
         client : Optional[&quot;DataverseClient&quot;], optional
-            _description_, by default None
         client_alias : Optional[str], optional
-            _description_, by default None
 
         Returns
         -------
@@ -858,47 +855,6 @@ class DataverseClient:
             raise
         except Exception:
             logging.exception("Failed to get model label file")
-            return False, save_path
-
-    @staticmethod
-    def get_triton_model_file(
-        model_id: int,
-        save_path: str = "./model.zip",
-        timeout: int = 3000,
-        client: Optional["DataverseClient"] = None,
-        client_alias: Optional[str] = None,
-    ) -> tuple[bool, str]:
-        """Download the triton model file (which is a zip file)
-
-        Parameters
-        ----------
-        model_id : int
-        save_path : str, optional
-            local path for saving the triton model file, by default './model.zip'
-        timeout : int, optional
-            maximum timeout of the request, by default 3000
-        client : Optional[&quot;DataverseClient&quot;], optional
-            client class, by default None
-        client_alias: Optional[str], by default None (should be provided if client is None)
-
-        Returns
-        -------
-        (status, save_path): tuple[bool, str]
-            the first item means whether the download success or not
-            the second item shows the save_path
-        """
-        api, client_alias = DataverseClient._get_api_client(
-            client=client, client_alias=client_alias
-        )
-        try:
-            resp = api.get_ml_model_file(model_id=model_id, timeout=timeout)
-            download_file_from_response(response=resp, save_path=save_path)
-            return True, save_path
-        except DataverseExceptionBase:
-            logging.exception("Got api error from Dataverse")
-            raise
-        except Exception:
-            logging.exception("Failed to get triton model file")
             return False, save_path
 
     @staticmethod

--- a/python/dataverse_sdk/client.py
+++ b/python/dataverse_sdk/client.py
@@ -309,7 +309,7 @@ class DataverseClient:
 
     def update_alias(self, project_id: int, alias_list: list):
         try:
-            resp: dict = self._api_client.update_alias(
+            resp = self._api_client.update_alias(
                 project_id=project_id, alias_list=alias_list
             )
         except DataverseExceptionBase as api_error:

--- a/python/dataverse_sdk/client.py
+++ b/python/dataverse_sdk/client.py
@@ -787,13 +787,11 @@ class DataverseClient:
 
         Returns
         -------
-        _type_
-            _description_
+        ConvertRecord
 
         Raises
         ------
         ClientConnectionError
-            _description_
         """
         api, client_alias = DataverseClient._get_api_client(
             client=client, client_alias=client_alias
@@ -873,7 +871,7 @@ class DataverseClient:
         ----------
         convert_record_id : int
         save_path : str, optional
-            local path for saving the onnx model file, by default './model.onnx'
+            local path for saving the model file, by default './triton.zip'
         triton_format: bool, default=True
         timeout : int, optional
             maximum timeout of the request, by default 3000

--- a/python/dataverse_sdk/client.py
+++ b/python/dataverse_sdk/client.py
@@ -403,7 +403,6 @@ class DataverseClient:
                 reader = csv.DictReader(csvfile)
                 for row in reader:
                     if row["alias"]:
-                        print(row)
                         if int(row["ID"]) in project_ontology_ids[row["type"]]:
                             alias_list.append(
                                 {row["type"]: int(row["ID"]), "name": row["alias"]}

--- a/python/dataverse_sdk/client.py
+++ b/python/dataverse_sdk/client.py
@@ -416,6 +416,10 @@ class DataverseClient:
                 project_ontology_ids["attribute"].add(attr.id)
                 for option in attr.options:
                     project_ontology_ids["option"].add(option.id)
+        for attr in project.project_tag.attributes:
+            project_ontology_ids["attribute"].add(attr.id)
+            for option in attr.options:
+                project_ontology_ids["option"].add(option.id)
 
         import csv
 
@@ -428,6 +432,12 @@ class DataverseClient:
                         if int(row["ID"]) in project_ontology_ids[row["type"]]:
                             alias_list.append(
                                 {row["type"]: int(row["ID"]), "name": row["alias"]}
+                            )
+                            project_ontology_ids[row["type"]].remove(int(row["ID"]))
+                        else:
+                            print(
+                                f"The ID {int(row['ID'])}, {row['alias']}, is not belong to {row['type']} \
+of this project OR has been added before"
                             )
         except FileNotFoundError as file_not_found:
             raise InvalidProcessError(f"File Not Found: {file_not_found}")

--- a/python/dataverse_sdk/client.py
+++ b/python/dataverse_sdk/client.py
@@ -361,6 +361,28 @@ class DataverseClient:
                                     "",
                                 ]
                             )
+
+        # add project tags attributes/option to alias map
+        for attr in project.project_tag.attributes:
+            alias_mapping.append(
+                [
+                    attr.id,
+                    "attribute",
+                    f"**tagging--{attr.name}",
+                    "",
+                ]
+            )
+            if attr.options:
+                for option in attr.options:
+                    alias_mapping.append(
+                        [
+                            option.id,
+                            "option",
+                            f"**tagging--{attr.name}--{option.value}",
+                            "",
+                        ]
+                    )
+
         # output alias mapping to csv
         import csv
 

--- a/python/dataverse_sdk/client.py
+++ b/python/dataverse_sdk/client.py
@@ -777,6 +777,27 @@ class DataverseClient:
         client: Optional["DataverseClient"] = None,
         client_alias: Optional[str] = None,
     ):
+        """_summary_
+
+        Parameters
+        ----------
+        convert_record_id : int
+            _description_
+        client : Optional[&quot;DataverseClient&quot;], optional
+            _description_, by default None
+        client_alias : Optional[str], optional
+            _description_, by default None
+
+        Returns
+        -------
+        _type_
+            _description_
+
+        Raises
+        ------
+        ClientConnectionError
+            _description_
+        """
         api, client_alias = DataverseClient._get_api_client(
             client=client, client_alias=client_alias
         )
@@ -798,7 +819,7 @@ class DataverseClient:
 
     @staticmethod
     def get_label_file(
-        model_id: int,
+        convert_record_id: int,
         save_path: str = "./labels.txt",
         timeout: int = 3000,
         client: Optional["DataverseClient"] = None,
@@ -808,7 +829,7 @@ class DataverseClient:
 
         Parameters
         ----------
-        model_id : int
+        convert_record_id : int
         save_path : str, optional
             local path for saving the label_file, by default './labels.txt'
         timeout : int, optional
@@ -827,7 +848,9 @@ class DataverseClient:
             client=client, client_alias=client_alias
         )
         try:
-            resp = api.get_ml_model_labels(model_id=model_id, timeout=timeout)
+            resp = api.get_convert_model_labels(
+                convert_record_id=convert_record_id, timeout=timeout
+            )
             download_file_from_response(response=resp, save_path=save_path)
             return True, save_path
         except DataverseExceptionBase:
@@ -879,20 +902,23 @@ class DataverseClient:
             return False, save_path
 
     @staticmethod
-    def get_onnx_model_file(
-        model_id: int,
-        save_path: str = "./model.onnx",
+    def get_convert_model_file(
+        convert_record_id: int,
+        save_path: str = "./triton.zip",
+        triton_format: bool = True,
         timeout: int = 3000,
+        permission: str = "",
         client: Optional["DataverseClient"] = None,
         client_alias: Optional[str] = None,
     ) -> tuple[bool, str]:
-        """Download the onnx model file
+        """Download convert model file
 
         Parameters
         ----------
-        model_id : int
+        convert_record_id : int
         save_path : str, optional
             local path for saving the onnx model file, by default './model.onnx'
+        triton_format: bool, default=True
         timeout : int, optional
             maximum timeout of the request, by default 3000
         client : Optional['DataverseClient'], optional
@@ -909,8 +935,11 @@ class DataverseClient:
             client=client, client_alias=client_alias
         )
         try:
-            resp = api.get_ml_model_file(
-                model_id=model_id, timeout=timeout, model_format="onnx"
+            resp = api.get_convert_model_file(
+                convert_record_id=convert_record_id,
+                triton_format=triton_format,
+                timeout=timeout,
+                permission=permission,
             )
             download_file_from_response(response=resp, save_path=save_path)
             return True, save_path

--- a/python/dataverse_sdk/exceptions/client.py
+++ b/python/dataverse_sdk/exceptions/client.py
@@ -1,6 +1,10 @@
 from typing import Optional
 
 
+class InvalidProcessError(Exception):
+    pass
+
+
 class ClientConnectionError(Exception):
     pass
 
@@ -12,7 +16,7 @@ class DataverseExceptionBase(Exception):
         type: Optional[str] = None,
         detail: Optional[str] = None,
         error: Optional[str | dict] = None,
-        **args
+        **args,
     ):
         self.type = type
         self.status_code = status_code

--- a/python/dataverse_sdk/schemas/client.py
+++ b/python/dataverse_sdk/schemas/client.py
@@ -209,6 +209,15 @@ class Project(BaseModel):
         )
         return model_data
 
+    def get_convert_record(self, convert_record_id: int):
+        from ..client import DataverseClient
+
+        convert_record_data = DataverseClient.get_convert_record(
+            convert_record_id=convert_record_id,
+            client_alias=self.client_alias,
+        )
+        return convert_record_data
+
     def create_dataset(
         self,
         name: str,
@@ -342,6 +351,7 @@ class MLModel(BaseModel):
     updated_at: str
     project: Project
     classes: list
+    model_records: list = []
     triton_model_name: str
     description: Optional[str] = None
 
@@ -376,6 +386,7 @@ class MLModel(BaseModel):
             name=model_data["name"],
             project=project,
             classes=classes,
+            model_records=model_data.get("model_records", []),
             updated_at=model_data["updated_at"],
             triton_model_name=model_data["triton_model_name"],
             client_alias=client_alias,
@@ -416,3 +427,13 @@ class MLModel(BaseModel):
             timeout=timeout,
             client_alias=self.client_alias,
         )
+
+
+class ConvertRecord(BaseModel):
+    id: Optional[int] = None
+    name: str
+    client_alias: str
+    configuration: dict
+
+    class Config:
+        extra = "allow"

--- a/python/dataverse_sdk/schemas/client.py
+++ b/python/dataverse_sdk/schemas/client.py
@@ -68,19 +68,30 @@ class Sensor(BaseModel):
 class OntologyClass(BaseModel):
     id: Optional[int] = None
     name: str
-    color: str
-    rank: Optional[int] = None
+    color: Optional[str] = "#cc39f4"
+    rank: Optional[int] = 1
     attributes: Optional[list[Attribute]] = None
     aliases: Optional[list] = None
 
-    @validator("color", each_item=True)
+    class Config:
+        validate_assignment = True
+
+    @validator("color", pre=True, always=True)
     def color_validator(cls, value):
+        if not value:
+            value = "#cc39f4"
         if not value.startswith("#") or not re.search(
             r"\b[a-zA-Z0-9]{6}\b", value.lstrip("#")
         ):
             raise ValueError(
                 f"Color field needs starts with `#` and has 6 digits behind it, get : {value}"
             )
+        return value
+
+    @validator("rank", pre=True, always=True)
+    def rank_validator(cls, value):
+        if not value:
+            value = 1
         return value
 
 
@@ -100,7 +111,7 @@ class Ontology(BaseModel):
             OntologyClass(
                 id=cls_["id"],
                 name=cls_["name"],
-                color=cls_.get("color", "#234567"),
+                color=cls_.get("color"),
                 rank=cls_.get("rank"),
                 attributes=cls_.get("attributes"),
             )

--- a/python/dataverse_sdk/schemas/client.py
+++ b/python/dataverse_sdk/schemas/client.py
@@ -97,15 +97,15 @@ class Ontology(BaseModel):
             OntologyClass(
                 id=cls_["id"],
                 name=cls_["name"],
-                color=cls_["color"],
-                rank=cls_["rank"],
-                attributes=cls_["attributes"],
+                color=cls_.get("color", "#234567"),
+                rank=cls_.get("rank"),
+                attributes=cls_.get("attributes"),
             )
             for cls_ in ontology_data["classes"]
         ]
         return cls(
             id=ontology_data["id"],
-            name=ontology_data["name"],
+            name=ontology_data.get("name", ""),
             image_type=ontology_data["image_type"],
             pcd_type=ontology_data["pcd_type"],
             classes=classes,
@@ -139,7 +139,7 @@ class Project(BaseModel):
             id=project_data["id"],
             name=project_data["name"],
             description=project_data["description"],
-            ego_car=project_data["ego_car"],
+            ego_car=project_data.get("ego_car"),
             ontology=ontology,
             sensors=sensors,
             project_tag=project_tag,

--- a/python/dataverse_sdk/schemas/client.py
+++ b/python/dataverse_sdk/schemas/client.py
@@ -18,6 +18,7 @@ from .common import (
 class AttributeOption(BaseModel):
     id: Optional[int] = None
     value: Union[str, float, int, bool]
+    aliases: Optional[list] = None
 
 
 class Attribute(BaseModel):
@@ -25,6 +26,7 @@ class Attribute(BaseModel):
     name: str
     options: Optional[list[AttributeOption]] = None
     type: AttributeType
+    aliases: Optional[list] = None
 
     class Config:
         use_enum_values = True
@@ -69,6 +71,7 @@ class OntologyClass(BaseModel):
     color: str
     rank: Optional[int] = None
     attributes: Optional[list[Attribute]] = None
+    aliases: Optional[list] = None
 
     @validator("color", each_item=True)
     def color_validator(cls, value):

--- a/python/dataverse_sdk/schemas/client.py
+++ b/python/dataverse_sdk/schemas/client.py
@@ -344,6 +344,46 @@ class Dataset(BaseModel):
         extra = "allow"
 
 
+class ConvertRecord(BaseModel):
+    id: Optional[int] = None
+    name: str
+    client_alias: str
+    configuration: dict
+
+    class Config:
+        extra = "allow"
+
+    def get_label_file(
+        self, save_path: str = "./labels.txt", timeout: int = 3000
+    ) -> tuple[bool, str]:
+        from ..client import DataverseClient
+
+        return DataverseClient.get_label_file(
+            convert_record_id=self.id,
+            save_path=save_path,
+            timeout=timeout,
+            client_alias=self.client_alias,
+        )
+
+    def get_convert_model_file(
+        self,
+        triton_format: bool = True,
+        save_path: str = "./triton.zip",
+        timeout: int = 3000,
+        permission: str = "",
+    ) -> tuple[bool, str]:
+        from ..client import DataverseClient
+
+        return DataverseClient.get_convert_model_file(
+            convert_record_id=self.id,
+            save_path=save_path,
+            triton_format=triton_format,
+            timeout=timeout,
+            permission=permission,
+            client_alias=self.client_alias,
+        )
+
+
 class MLModel(BaseModel):
     id: Optional[int] = None
     name: str
@@ -392,54 +432,9 @@ class MLModel(BaseModel):
             client_alias=client_alias,
         )
 
-    def get_triton_model_file(
-        self, save_path: str = "./model.zip", timeout: int = 3000
-    ) -> tuple[bool, str]:
+    def get_convert_record(self, convert_record_id: int) -> ConvertRecord:
         from ..client import DataverseClient
 
-        return DataverseClient.get_triton_model_file(
-            model_id=self.id,
-            save_path=save_path,
-            timeout=timeout,
-            client_alias=self.client_alias,
-        )
-
-
-class ConvertRecord(BaseModel):
-    id: Optional[int] = None
-    name: str
-    client_alias: str
-    configuration: dict
-
-    class Config:
-        extra = "allow"
-
-    def get_label_file(
-        self, save_path: str = "./labels.txt", timeout: int = 3000
-    ) -> tuple[bool, str]:
-        from ..client import DataverseClient
-
-        return DataverseClient.get_label_file(
-            convert_record_id=self.id,
-            save_path=save_path,
-            timeout=timeout,
-            client_alias=self.client_alias,
-        )
-
-    def get_convert_model_file(
-        self,
-        triton_format: bool = True,
-        save_path: str = "./triton.zip",
-        timeout: int = 3000,
-        permission: str = "",
-    ) -> tuple[bool, str]:
-        from ..client import DataverseClient
-
-        return DataverseClient.get_convert_model_file(
-            convert_record_id=self.id,
-            save_path=save_path,
-            triton_format=triton_format,
-            timeout=timeout,
-            permission=permission,
-            client_alias=self.client_alias,
+        return DataverseClient.get_convert_record(
+            convert_record_id=convert_record_id, client_alias=self.client_alias
         )

--- a/python/dataverse_sdk/schemas/client.py
+++ b/python/dataverse_sdk/schemas/client.py
@@ -392,36 +392,12 @@ class MLModel(BaseModel):
             client_alias=client_alias,
         )
 
-    def get_label_file(
-        self, save_path: str = "./labels.txt", timeout: int = 3000
-    ) -> tuple[bool, str]:
-        from ..client import DataverseClient
-
-        return DataverseClient.get_label_file(
-            model_id=self.id,
-            save_path=save_path,
-            timeout=timeout,
-            client_alias=self.client_alias,
-        )
-
     def get_triton_model_file(
         self, save_path: str = "./model.zip", timeout: int = 3000
     ) -> tuple[bool, str]:
         from ..client import DataverseClient
 
         return DataverseClient.get_triton_model_file(
-            model_id=self.id,
-            save_path=save_path,
-            timeout=timeout,
-            client_alias=self.client_alias,
-        )
-
-    def get_onnx_model_file(
-        self, save_path: str = "./model.onnx", timeout: int = 3000
-    ) -> tuple[bool, str]:
-        from ..client import DataverseClient
-
-        return DataverseClient.get_onnx_model_file(
             model_id=self.id,
             save_path=save_path,
             timeout=timeout,
@@ -437,3 +413,33 @@ class ConvertRecord(BaseModel):
 
     class Config:
         extra = "allow"
+
+    def get_label_file(
+        self, save_path: str = "./labels.txt", timeout: int = 3000
+    ) -> tuple[bool, str]:
+        from ..client import DataverseClient
+
+        return DataverseClient.get_label_file(
+            convert_record_id=self.id,
+            save_path=save_path,
+            timeout=timeout,
+            client_alias=self.client_alias,
+        )
+
+    def get_convert_model_file(
+        self,
+        triton_format: bool = True,
+        save_path: str = "./triton.zip",
+        timeout: int = 3000,
+        permission: str = "",
+    ) -> tuple[bool, str]:
+        from ..client import DataverseClient
+
+        return DataverseClient.get_convert_model_file(
+            convert_record_id=self.id,
+            save_path=save_path,
+            triton_format=triton_format,
+            timeout=timeout,
+            permission=permission,
+            client_alias=self.client_alias,
+        )

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "dataverse-sdk"
-PACKAGE_VERSION = "1.4.1"
+PACKAGE_VERSION = "1.5.0"
 DESC = "Dataverse SDK For Python"
 with open("README.md", encoding="utf-8") as fh:
     long_description = fh.read()


### PR DESCRIPTION
## Purpose

<!-- Fill the task or bug ID in azure board AB#{ID} -->
- [AB#23572](https://dev.azure.com/linkerengineer/87361b6b-4b8a-4d65-8243-96cf1163a72f/_workitems/edit/23572)
- [AB#22771](https://dev.azure.com/linkerengineer/87361b6b-4b8a-4d65-8243-96cf1163a72f/_workitems/edit/22771)

## What Changes?

<!-- For new feature is what you add and how to use it, for the bug is how to fix it. -->
- Add function for generating alias mapping table from project ontology
- Add function for updating alias
- Add function for getting Model Convert Records
- Adjust function for downloading converted models.

## What to Check?

<!-- Describe steps to verify the functions of this PR -->
** Step for updating alias
1. Get the csv file of alias map for your project
```Python
client.generate_alias_map(project_id=123, alias_file_path="./alias.csv")
```
The table is as below.
<img width="404" alt="image" src="https://github.com/user-attachments/assets/721a1c71-d9a6-430e-87d2-792d60292fc8">


2. Fill the alias in the csv file and save (DO NOT modify other fields)

3. Update alias for your project with the alias file path
```Python
client.update_alias(project_id=123, alias_file_path= "/Users/Downloads/alias.csv" )
```
Alias could be updated.
![image](https://github.com/user-attachments/assets/66d76b55-935a-48c4-a6d5-99634dc4b73d)


** Getting converted model

From the given model, we could get the model convert records as below
```Python
model_record = client.get_convert_record(convert_record_id=1, client_alias=client.alias)
OR
model_record = model.get_convert_record(convert_record_id=1)
```

For the convert model files we could download as below.
``` Python
status, triton_model_path = model_record.get_convert_model_file( triton_format=True,  permission= "****", save_path="./model.zip", timeout=6000)
status, label_file_path = model_records.get_label_file(save_path = "./labels.txt")
```


