### PR TITLE
fix(python): output current alias name for alias mapping table

### DIFF
--- a/python/dataverse_sdk/client.py
+++ b/python/dataverse_sdk/client.py
@@ -338,48 +338,62 @@ class DataverseClient:
 
         alias_mapping = []
         for ontology_class in project.ontology.classes:
+            class_alias = (
+                ontology_class.aliases[0]["name"] if ontology_class.aliases else ""
+            )
             alias_mapping.append(
-                [ontology_class.id, "ontology_class", ontology_class.name, ""]
+                [
+                    ontology_class.id,
+                    "ontology_class",
+                    ontology_class.name,
+                    class_alias,
+                ]
             )
             if ontology_class.attributes:
                 for attr in ontology_class.attributes:
+                    attr_alias = attr.aliases[0]["name"] if attr.aliases else ""
                     alias_mapping.append(
                         [
                             attr.id,
                             "attribute",
                             f"{ontology_class.name}--{attr.name}",
-                            "",
+                            attr_alias,
                         ]
                     )
                     if attr.options:
                         for option in attr.options:
+                            option_alias = (
+                                option.aliases[0]["name"] if option.aliases else ""
+                            )
                             alias_mapping.append(
                                 [
                                     option.id,
                                     "option",
                                     f"{ontology_class.name}--{attr.name}--{option.value}",
-                                    "",
+                                    option_alias,
                                 ]
                             )
 
         # add project tags attributes/option to alias map
         for attr in project.project_tag.attributes:
+            attr_alias = attr.aliases[0]["name"] if attr.aliases else ""
             alias_mapping.append(
                 [
                     attr.id,
                     "attribute",
                     f"**tagging--{attr.name}",
-                    "",
+                    attr_alias,
                 ]
             )
             if attr.options:
                 for option in attr.options:
+                    option_alias = option.aliases[0]["name"] if option.aliases else ""
                     alias_mapping.append(
                         [
                             option.id,
                             "option",
                             f"**tagging--{attr.name}--{option.value}",
-                            "",
+                            option_alias,
                         ]
                     )
 
@@ -436,6 +450,12 @@ class DataverseClient:
                             and not row["alias"]
                         ):
                             # ignore alias for both before-update and after-update are empty
+                            continue
+                        if (
+                            row["alias"]
+                            in project_ontology_ids[row["type"]][int(row["ID"])]
+                        ):
+                            # ignore alias is same as current setting
                             continue
                         alias_list.append(
                             {row["type"]: int(row["ID"]), "name": row["alias"]}

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "dataverse-sdk"
-PACKAGE_VERSION = "1.5.2"
+PACKAGE_VERSION = "1.5.3"
 DESC = "Dataverse SDK For Python"
 with open("README.md", encoding="utf-8") as fh:
     long_description = fh.read()


### PR DESCRIPTION
## Purpose

<!-- Briefly describe the purpose of this PR -->
...

<!-- Fill the task or bug ID in azure board AB#{ID} -->
- [AB#24237](https://dev.azure.com/linkerengineer/87361b6b-4b8a-4d65-8243-96cf1163a72f/_workitems/edit/24237)


## What Changes?

<!-- For new feature is what you add and how to use it, for the bug is how to fix it. -->
- Output current alias name when generating alias mapping table
- Check whether the updated value is same as current setting.

## What to Check?

<!-- Describe steps to verify the functions of this PR -->
- The original csv table will contain current alias name and aliases could be updated successfully.
![image](https://github.com/user-attachments/assets/8263b9f1-08dc-4b4c-a8e9-b9b186564ae6)


