### PR TITLE
feat(python): support resumeable dataset upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+report/
 
 # Mac OS
 .DS_Store

--- a/python/dataverse_sdk/client.py
+++ b/python/dataverse_sdk/client.py
@@ -1,7 +1,8 @@
 import asyncio
+import json
 import logging
 import os
-from asyncio import Semaphore
+from asyncio import AbstractEventLoop, Semaphore
 from collections import deque
 from pathlib import Path
 from typing import Optional, Union
@@ -1460,6 +1461,7 @@ of this project OR has been added before"
         client_alias: Optional[str] = None,
         access_key_id: Optional[str] = None,
         secret_access_key: Optional[str] = None,
+        reupload_dataset_uuid: Optional[str] = None,
         **kwargs,
     ) -> Dataset:
         """Create Dataset
@@ -1568,7 +1570,7 @@ of this project OR has been added before"
 
         if data_source == DataSource.LOCAL:
             create_dataset_uuid = DataverseClient.upload_files_from_local(
-                async_api, api, raw_dataset_data
+                async_api, api, raw_dataset_data, reupload_dataset_uuid
             )
             raw_dataset_data["create_dataset_uuid"] = create_dataset_uuid
         dataset_data = api.create_dataset(**raw_dataset_data)
@@ -1585,9 +1587,65 @@ of this project OR has been added before"
 
     @staticmethod
     def upload_files_from_local(
-        async_api: AsyncBackendAPI, api: BackendAPI, raw_dataset_data: dict
-    ) -> dict:
-        loop = asyncio.get_event_loop()
+        async_api: AsyncBackendAPI,
+        api: BackendAPI,
+        raw_dataset_data: dict,
+        reupload_dataset_uuid: str | None = None,
+    ) -> str:
+        def run_new_upload_tasks(
+            data_folder: str,
+            async_api_client: AsyncBackendAPI,
+            event_loop: AbstractEventLoop,
+        ):
+            print("Uploading new dataset from [%s]...", data_folder)
+
+            file_paths = DataverseClient._find_all_paths(data_folder)
+            (
+                upload_task_queue,
+                create_dataset_uuid,
+                failed_urls,
+            ) = event_loop.run_until_complete(
+                DataverseClient.run_generate_presigned_urls(
+                    file_paths=file_paths, api=async_api_client, data_folder=data_folder
+                )
+            )
+            if failed_urls:
+                raise ClientConnectionError(
+                    f"unable to generate urls for: {failed_urls}"
+                )
+
+            if not create_dataset_uuid:
+                raise ClientConnectionError(
+                    "something went wrong, missing create dataset uuid"
+                )
+            failed_file_info_batches = event_loop.run_until_complete(
+                DataverseClient.run_upload_tasks(upload_task_queue)
+            )
+
+            return create_dataset_uuid, failed_file_info_batches
+
+        def run_reupload_tasks(
+            reupload_dataset_uuid: str, event_loop: AbstractEventLoop
+        ):
+            print("Reuploading dataset from [%s]...", data_folder)
+
+            prev_failed_report_path = (
+                Path.cwd() / "report" / reupload_dataset_uuid / "failed_upload.json"
+            )
+            with open(prev_failed_report_path) as f:
+                failed_report = json.load(f)
+
+            failed_file_info_list = failed_report["failed_file_info_list"]
+            upload_task_queue = deque(failed_file_info_list)
+
+            failed_file_info_batches = event_loop.run_until_complete(
+                DataverseClient.run_upload_tasks(upload_task_queue)
+            )
+            if not failed_file_info_batches:
+                prev_failed_report_path.unlink(missing_ok=True)
+
+            return reupload_dataset_uuid, failed_file_info_batches
+
         data_folder = raw_dataset_data["data_folder"]
         dataset_type = raw_dataset_data["type"]
 
@@ -1607,36 +1665,42 @@ of this project OR has been added before"
                         detail=f"Require the file or folder: {path} for {raw_dataset_data['annotation_format']}",
                     )
 
-        file_paths = DataverseClient._find_all_paths(data_folder)
-        upload_task_queue, create_dataset_uuid, failed_urls = loop.run_until_complete(
-            DataverseClient.run_generate_presigned_urls(
-                file_paths=file_paths, api=async_api, data_folder=data_folder
-            )
+        loop = asyncio.get_event_loop()
+        create_dataset_uuid, failed_file_info_batches = (
+            run_reupload_tasks(reupload_dataset_uuid, loop)
+            if reupload_dataset_uuid
+            else run_new_upload_tasks(data_folder, async_api, loop)
         )
-        if failed_urls:
-            raise ClientConnectionError(f"unable to generate urls for: {failed_urls}")
 
-        if not create_dataset_uuid:
+        if failed_file_info_batches:
+            failed_report_path = (
+                Path.cwd() / "report" / create_dataset_uuid / "failed_upload.json"
+            )
+            failed_report_path.parent.mkdir(parents=True, exist_ok=True)
+            report = {
+                "dataset_uuid": create_dataset_uuid,
+                "failed_file_info_list": failed_file_info_batches,
+            }
+
+            with open(failed_report_path, "w") as f:
+                json.dump(report, f)
+
             raise ClientConnectionError(
-                "something went wrong, missing create dataset uuid"
+                f"Failed to upload the dataset [{create_dataset_uuid}].\n"
+                f"A detailed report has been saved to: {failed_report_path}"
             )
 
-        failed_urls = loop.run_until_complete(
-            DataverseClient.run_upload_tasks(upload_task_queue)
-        )
-        if failed_urls:
-            raise ClientConnectionError(f"failed to upload urls: {failed_urls}")
         return create_dataset_uuid
 
     @staticmethod
     async def run_generate_presigned_urls(
         file_paths: list, api: AsyncBackendAPI, data_folder: str
-    ) -> tuple[deque, str, list[str]]:
-        max_retry_count, batch_size, max_concurrent_api_calls = 3, 500, 10
+    ) -> tuple[deque[tuple[list[str], list[dict]]], str, list[str]]:
+        max_retry_count, batch_size, max_concurrent_api_calls = 5, 500, 10
         semaphore = asyncio.Semaphore(max_concurrent_api_calls)
 
-        failed_urls = []
-        upload_task_queue = deque()
+        failed_urls: list[str] = []
+        upload_task_queue: deque[tuple[list[str], list[dict]]] = deque()
 
         data_folder = Path(data_folder).resolve()
         create_dataset_uuid: str = str(uuid4())
@@ -1674,6 +1738,7 @@ of this project OR has been added before"
                     raise
                 except Exception as e:
                     logging.warning(f"Retrying batch due to error: {e}")
+                    await asyncio.sleep(retry_count**2)
                     await generate_presigned_url_task(
                         batched_file_paths, retry_count + 1
                     )
@@ -1688,7 +1753,65 @@ of this project OR has been added before"
         return upload_task_queue, create_dataset_uuid, failed_urls
 
     @staticmethod
-    async def run_upload_tasks(upload_task_queue: deque) -> list[str]:
+    async def run_upload_tasks(upload_task_queue: deque[tuple[list[str], list[dict]]]):
+        async def upload_batch(
+            paths: list[str],
+            upload_infos: list[dict],
+            async_client: AsyncThirdPartyAPI,
+            semaphore: Semaphore,
+            progress_bar: tqdm_asyncio,
+        ) -> tuple[list[str], list[dict[str, str]]] | None:
+            async def upload_file(path: str, info: dict):
+                async with semaphore:
+                    try:
+                        async with aio_open(path, "rb") as file:
+                            file_content = await file.read()
+                            await async_client.upload_file(
+                                method="PUT",
+                                target_url=info["url"],
+                                file=file_content,
+                                content_type="application/octet-stream",
+                            )
+                            progress_bar.update(1)
+                    except Exception as e:
+                        logging.exception(e)
+                        return (path, info)
+                    # finally:
+                    #     progress_bar.update(1)
+
+            remaining_files = (file for file in zip(paths, upload_infos, strict=True))
+            attempt_count, max_retry_count = 1, 1
+            while attempt_count <= max_retry_count:
+                print("🔁 Upload file batch (%d/%d) ...", attempt_count, max_retry_count)
+
+                upload_tasks = (
+                    upload_file(path, info) for path, info in remaining_files
+                )
+                failed_files = await asyncio.gather(*upload_tasks)
+                if not any(failed_files):
+                    print(
+                        "✅ Upload file batch successful on attempt (%d/%d)",
+                        attempt_count,
+                        max_retry_count,
+                    )
+                    return None
+
+                remaining_files = (file for file in failed_files if file)
+                print(
+                    "❌ Upload file batch failed on attempt (%d/%d)",
+                    attempt_count,
+                    max_retry_count,
+                )
+
+                await asyncio.sleep(attempt_count**2)
+                attempt_count += 1
+
+            failed_files = list(remaining_files)
+            failed_paths = [path for path, _ in failed_files]
+            failed_remote_urls = [{"url": info["url"]} for _, info in failed_files]
+
+            return (failed_paths, failed_remote_urls)
+
         tasks = []
         client = AsyncThirdPartyAPI()
         semaphore = Semaphore(MAX_CONCURRENT_FILES)
@@ -1696,48 +1819,25 @@ of this project OR has been added before"
         progress_bar = tqdm_asyncio(
             total=total_files, desc="Uploading files", unit="file"
         )
+
         for batched_file_paths, upload_file_infos in upload_task_queue:
+            tasks.append(
+                upload_batch(
+                    batched_file_paths,
+                    upload_file_infos,
+                    client,
+                    semaphore,
+                    progress_bar,
+                )
+            )
 
-            async def upload_batch(
-                paths: list[str],
-                upload_infos: list[dict],
-                async_client: AsyncThirdPartyAPI,
-            ) -> list[str]:
-                failed_urls = []
-
-                async def upload_file(path: str, info: dict):
-                    async with semaphore:
-                        try:
-                            async with aio_open(path, "rb") as file:
-                                file_content = await file.read()
-                                await async_client.upload_file(
-                                    method=info["method"],
-                                    target_url=info["url"],
-                                    file=file_content,
-                                    content_type=info["content_type"],
-                                )
-                        except Exception as e:
-                            logging.exception(e)
-                            failed_urls.append(path)
-                        finally:
-                            progress_bar.update(1)
-
-                upload_tasks = [
-                    upload_file(path, info) for path, info in zip(paths, upload_infos)
-                ]
-
-                await asyncio.gather(*upload_tasks)
-
-                return failed_urls
-
-            tasks.append(upload_batch(batched_file_paths, upload_file_infos, client))
-
-        failed_urls = []
+        failed_file_info_list: list[tuple[list[str], list[dict[str, str]]]] = []
         for results in await tqdm_asyncio.gather(*tasks):
-            failed_urls.extend(results)
+            if results:
+                failed_file_info_list.append(results)
 
         progress_bar.close()
-        return failed_urls
+        return failed_file_info_list
 
     @staticmethod
     def _find_all_paths(*paths) -> list[str]:
@@ -1797,15 +1897,14 @@ class AsyncThirdPartyAPI:
     async def async_send_request(self, url: str, method: str, **kwargs) -> Response:
         try:
             resp: Response = await self.client.request(method=method, url=url, **kwargs)
-
         except Exception:
             logging.exception("async send request error")
+            raise
 
         if not 200 <= resp.status_code <= 299:
             raise AsyncThirdPartyAPIException(
-                status_code=resp.status_code, detail=resp.content
+                status_code=resp.status_code, detail=resp.json().content
             )
-
         return resp
 
     async def upload_file(

--- a/python/dataverse_sdk/client.py
+++ b/python/dataverse_sdk/client.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import os
+import platform
 from asyncio import AbstractEventLoop, Semaphore
 from collections import deque
 from pathlib import Path
@@ -54,7 +55,13 @@ from .utils.utils import (
     get_filepaths,
 )
 
-MAX_CONCURRENT_FILES = 100
+
+def is_macOS():
+    return platform.system() == "Darwin"
+
+
+# to avoid the `Too many open files` error in macOS
+MAX_CONCURRENT_FILES = 70 if is_macOS() else 100
 
 
 def parse_attribute(attr_list: list) -> list:

--- a/python/dataverse_sdk/client.py
+++ b/python/dataverse_sdk/client.py
@@ -1622,7 +1622,7 @@ of this project OR has been added before"
                 upload_task_queue,
                 create_dataset_uuid,
                 failed_urls,
-            ) = event_loop.run_until_complete(
+            ) = asyncio.run(
                 DataverseClient.run_generate_presigned_urls(
                     file_paths=file_paths, api=async_api_client, data_folder=data_folder
                 )
@@ -1636,7 +1636,8 @@ of this project OR has been added before"
                 raise ClientConnectionError(
                     "something went wrong, missing create dataset uuid"
                 )
-            failed_file_info_batches = event_loop.run_until_complete(
+
+            failed_file_info_batches = asyncio.run(
                 DataverseClient.run_upload_tasks(upload_task_queue)
             )
 
@@ -1647,7 +1648,7 @@ of this project OR has been added before"
             provided_data_folder: str,
             event_loop: AbstractEventLoop,
         ):
-            print("Reuploading dataset from [%s]...", provided_data_folder)
+            print(f"Reuploading dataset from [{provided_data_folder}]...")
 
             prev_failed_report_path = (
                 Path.cwd() / "report" / reupload_dataset_uuid / "failed_upload.json"
@@ -1681,7 +1682,7 @@ of this project OR has been added before"
             failed_file_info_list = failed_report["failed_file_info_list"]
             upload_task_queue = deque(failed_file_info_list)
 
-            failed_file_info_batches = event_loop.run_until_complete(
+            failed_file_info_batches = asyncio.run(
                 DataverseClient.run_upload_tasks(upload_task_queue)
             )
             if not failed_file_info_batches:

--- a/python/dataverse_sdk/client.py
+++ b/python/dataverse_sdk/client.py
@@ -1923,11 +1923,11 @@ of this project OR has been added before"
 
 class AsyncThirdPartyAPI:
     transport = AsyncHTTPTransport(
-        retries=10,
+        retries=5,
     )
 
     def __init__(self):
-        self.client = AsyncClient(transport=self.transport, timeout=Timeout(100))
+        self.client = AsyncClient(transport=self.transport, timeout=Timeout(30))
 
     async def async_send_request(self, url: str, method: str, **kwargs) -> Response:
         try:

--- a/python/dataverse_sdk/client.py
+++ b/python/dataverse_sdk/client.py
@@ -1598,7 +1598,7 @@ of this project OR has been added before"
         async_api: AsyncBackendAPI,
         api: BackendAPI,
         raw_dataset_data: dict,
-        reupload_dataset_uuid: str | None = None,
+        reupload_dataset_uuid: Optional[str] = None,
     ) -> str:
         def run_new_upload_tasks(
             data_folder: str,

--- a/python/dataverse_sdk/client.py
+++ b/python/dataverse_sdk/client.py
@@ -1802,11 +1802,10 @@ of this project OR has been added before"
                                 file=file_content,
                                 content_type="application/octet-stream",
                             )
+                            progress_bar.update(1)
                     except Exception as e:
                         logging.exception(e)
                         return (path, info)
-                    finally:
-                        progress_bar.update(1)
 
             remaining_files = (file for file in zip(paths, upload_infos, strict=True))
             attempt_count = 1

--- a/python/dataverse_sdk/schemas/client.py
+++ b/python/dataverse_sdk/schemas/client.py
@@ -306,6 +306,7 @@ class Project(BaseModel):
         description: Optional[str] = None,
         access_key_id: Optional[str] = None,
         secret_access_key: Optional[str] = None,
+        reupload_dataset_uuid: Optional[str] = None,
         **kwargs,
     ):
         """Create Dataset From project itself
@@ -381,6 +382,7 @@ class Project(BaseModel):
             access_key_id=access_key_id,
             secret_access_key=secret_access_key,
             client_alias=self.client_alias,
+            reupload_dataset_uuid=reupload_dataset_uuid,
             **kwargs,
         )
         return dataset_output

--- a/python/dataverse_sdk/schemas/client.py
+++ b/python/dataverse_sdk/schemas/client.py
@@ -345,6 +345,9 @@ class Project(BaseModel):
             access key id for AWS s3 bucket, by default None
         secret_access_key : Optional[str], optional
             secret access key for AWS s3 bucket, by default None
+        reupload_dataset_uuid: Optional[str], optional
+            dataset UUID of a previously failed local dataset import. If provided, the files that failed to upload
+            (as recorded in `failed_upload.json`) will be re-uploaded, by default None
 
         Returns
         -------

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "dataverse-sdk"
-PACKAGE_VERSION = "2.1.3"
+PACKAGE_VERSION = "2.2.0"
 DESC = "Dataverse SDK For Python"
 with open("README.md", encoding="utf-8") as fh:
     long_description = fh.read()

--- a/python/tools/import_dataset_from_local.py
+++ b/python/tools/import_dataset_from_local.py
@@ -1,5 +1,7 @@
 import argparse
 import logging
+import time
+from typing import Optional
 
 from dataverse_sdk import DataverseClient
 from dataverse_sdk.constants import DataverseHost
@@ -23,6 +25,7 @@ def import_dataset_from_local(
     sequential: bool = False,
     gen_metadata: bool = False,
     gen_auto_tagging: bool = False,
+    reupload_dataset_uuid: Optional[str] = None,
     alias: str = "default",
 ):
     client = DataverseClient(
@@ -48,6 +51,7 @@ def import_dataset_from_local(
         "auto_tagging": AUTO_TAGGING_CLASSES if gen_auto_tagging else [],
         "annotation_format": annotation_format,
         "sequential": sequential,
+        "reupload_dataset_uuid": reupload_dataset_uuid,
     }
     if dataset_type == DatasetType.ANNOTATED_DATA:
         dataset_data["annotations"] = ["groundtruth"]
@@ -146,11 +150,20 @@ def make_parser():
         action="store_true",
         help="Whether generate auto_tagging for your dataset",
     )
+    parser.add_argument(
+        "-reupload",
+        "--reupload_dataset_uuid",
+        type=str,
+        default=None,
+        help="The dataset uuid of the reupload dataset",
+    )
 
     return parser.parse_args()
 
 
 if __name__ == "__main__":
+    start = time.time()
+
     args = make_parser()
     import_dataset_from_local(
         host=args.host,
@@ -166,4 +179,8 @@ if __name__ == "__main__":
         sequential=args.sequential,
         gen_metadata=args.metadata,
         gen_auto_tagging=args.auto_tagging,
+        reupload_dataset_uuid=args.reupload_dataset_uuid,
     )
+
+    end = time.time()
+    logging.info("import_dataset_from_local complete, duration: {%d}s", end - start)

--- a/python/tools/import_dataset_from_local.py
+++ b/python/tools/import_dataset_from_local.py
@@ -155,7 +155,7 @@ def make_parser():
         "--reupload_dataset_uuid",
         type=str,
         default=None,
-        help="The dataset uuid of the reupload dataset",
+        help="The dataset UUID to reupload.",
     )
 
     return parser.parse_args()

--- a/python/tools/import_dataset_from_local.py
+++ b/python/tools/import_dataset_from_local.py
@@ -155,7 +155,11 @@ def make_parser():
         "--reupload_dataset_uuid",
         type=str,
         default=None,
-        help="The dataset UUID to reupload.",
+        help=(
+            "Dataset UUID of a previously failed local dataset import. "
+            "If provided, the files that failed to upload (as recorded in `failed_upload.json`) "
+            "will be re-uploaded."
+        ),
     )
 
     return parser.parse_args()

--- a/python/tools/import_vqa_dataset.py
+++ b/python/tools/import_vqa_dataset.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import time
+from typing import Optional
 
 from dataverse_sdk import DataverseClient
 from dataverse_sdk.constants import DataverseHost
@@ -22,6 +23,7 @@ def import_vqa_dataset_from_local(
     sequential: bool = False,
     gen_metadata: bool = False,
     gen_auto_tagging: bool = False,
+    reupload_dataset_uuid: Optional[str] = None,
     alias: str = "default",
 ):
     client = DataverseClient(
@@ -47,6 +49,7 @@ def import_vqa_dataset_from_local(
         "auto_tagging": gen_auto_tagging,
         "annotation_format": annotation_format,
         "sequential": sequential,
+        "reupload_dataset_uuid": reupload_dataset_uuid,
     }
     if dataset_type == DatasetType.ANNOTATED_DATA:
         dataset_data["annotations"] = ["groundtruth"]
@@ -128,6 +131,17 @@ def make_parser():
         action="store_true",
         help="Whether generate metadata for your dataset",
     )
+    parser.add_argument(
+        "-reupload",
+        "--reupload_dataset_uuid",
+        type=str,
+        default=None,
+        help=(
+            "Dataset UUID of a previously failed local dataset import. "
+            "If provided, the files that failed to upload (as recorded in `failed_upload.json`) "
+            "will be re-uploaded."
+        ),
+    )
 
     return parser.parse_args()
 
@@ -154,4 +168,5 @@ if __name__ == "__main__":
         sequential=args.sequential,
         gen_metadata=args.metadata,
         gen_auto_tagging=[],
+        reupload_dataset_uuid=args.reupload_dataset_uuid,
     )


### PR DESCRIPTION
## Purpose

<!-- Briefly describe the purpose of this PR -->
Support resumeable dataset upload.

<!-- Fill the task or bug ID in azure board AB#{ID} -->
- [AB#28856](https://dev.azure.com/linkerengineer/87361b6b-4b8a-4d65-8243-96cf1163a72f/_workitems/edit/28856)


- Save failed file info to `{project_root}/{create_dataset_uuid}/failed_upload.json`.
**failed_upload.json example format**
```json
{
    "dataset_uuid": "ef8d5f34-8518-4742-bb65-99450000f9f8",
    "local_dataset_folder": "{local_dataset_folder_path}",
    "failed_file_info_list": [
        [
            [
                "/....../dataverse-sdk/....../cp_image_12.jpg",
                "/......r/dataverse-sdk/....../cp_image_14.jpg",
                "/....../dataverse-sdk/....../cp_image_28.jpg"
            ],
            [
                {
                    "url": "https://xxx.s3.amazonaws.com/....../ef8d5f34-8518-4742-bb65-99450000f9f8/cp_image_12.jpg?xxx"
                },
                {
                    "url": "https://xxx.s3.amazonaws.com/....../ef8d5f34-8518-4742-bb65-99450000f9f8/cp_image_14.jpg?xxx"
                },
                {
                    "url": "https://xxx.s3.amazonaws.com/....../ef8d5f34-8518-4742-bb65-99450000f9f8/cp_image_28.jpg?xxx"
                }
            ]
        ]
    ]
}
```

- Add `--reupload_dataset_uuid` option to `python/tools/import_dataset_from_local.py`.
    - Will only upload the failed files in `failed_upload.json` if `--reupload_dataset_uuid` provided.