### PR TITLE
feat(python): add logging filter to redact sensitive credentials from HTTP request logs

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -378,7 +378,7 @@ dataset2 = project.create_dataset(**dataset_data2)
 
 Your could also use the script for importing dataset from local
 ```
-python tools/import_dataset_from_local.py -host https://staging.visionai.linkervision.ai/dataverse/curation -e {your-account-email} -p {PASSWORD} -s {service-id}  -project {project-id} --folder {/YOUR/TARGET/LOCAL/FOLDER} -name {dataset-name} -type {raw_data OR annotated_data} -anno {image OR vision_ai} --sequential
+python tools/import_dataset_from_local.py -host https://staging.visionai.linkervision.com/dataverse/curation -e {your-account-email} -p {PASSWORD} -s {service-id}  -project {project-id} --folder {/YOUR/TARGET/LOCAL/FOLDER} -name {dataset-name} -type {raw_data OR annotated_data} -anno {image OR vision_ai} --sequential
 ```
 <br>
 
@@ -571,18 +571,18 @@ output = client.get_question_list(project_id=107, output_file_path="./question.j
 
 ### Import Your Local Dataset
 ```
-python tools/import_dataset_from_local.py -host https://staging.visionai.linkervision.ai/dataverse/curation -e {your-account-email} -p {PASSWORD} -s {service-id}  -project {project-id} --folder {/YOUR/TARGET/LOCAL/FOLDER} -name {dataset-name} -type {raw_data OR annotated_data} -anno {image OR vision_ai} --sequential
+python tools/import_dataset_from_local.py -host https://staging.visionai.linkervision.com/dataverse/curation -e {your-account-email} -p {PASSWORD} -s {service-id}  -project {project-id} --folder {/YOUR/TARGET/LOCAL/FOLDER} -name {dataset-name} -type {raw_data OR annotated_data} -anno {image OR vision_ai} --sequential
 ```
 
 ### Import VQA Local Dataset
 ```
-python tools/import_vqa_dataset.py -host https://staging.visionai.linkervision.ai/dataverse/curation -e {your-account-email} -p {PASSWORD} -s {service-id} -project {project-id} --folder {/YOUR/TARGET/LOCAL/FOLDER} -type {raw_data OR annotated_data}
+python tools/import_vqa_dataset.py -host https://staging.visionai.linkervision.com/dataverse/curation -e {your-account-email} -p {PASSWORD} -s {service-id} -project {project-id} --folder {/YOUR/TARGET/LOCAL/FOLDER} -type {raw_data OR annotated_data}
 
 ```
 
 ### Export Dataslice and download files
 ```
-python tools/export_dataslice.py -host https://staging.visionai.linkervision.ai/dataverse/curation  -e {your-account-email} -p {PASSWORD} -s {service-id} -dataslice {dataslice_id} -f {/YOUR/TARGET/LOCAL/file.zip}
+python tools/export_dataslice.py -host https://staging.visionai.linkervision.com/dataverse/curation  -e {your-account-email} -p {PASSWORD} -s {service-id} -dataslice {dataslice_id} -f {/YOUR/TARGET/LOCAL/file.zip}
 ```
 
 ### Export Large Dataslice and download files

--- a/python/dataverse_sdk/__init__.py
+++ b/python/dataverse_sdk/__init__.py
@@ -1,3 +1,6 @@
+import logging
+import re
+
 from . import connections
 from .client import DataverseClient
 from .constants import DataverseHost
@@ -45,3 +48,29 @@ __all__ = [
     "DataSource",
     "QuestionClass",
 ]
+
+
+class _SensitiveDataFilter(logging.Filter):
+    """Filter to redact sensitive credentials from logs"""
+
+    SENSITIVE_PATTERNS = [
+        (r"AWSAccessKeyId=[^&\s]*", "AWSAccessKeyId=***"),
+        (r"Signature=[^&\s]*", "Signature=***"),
+        (r"Expires=\d+", "Expires=***"),
+    ]
+
+    def filter(self, record):
+        # Override getMessage to process the final formatted message
+        original_getMessage = record.getMessage
+
+        def patched_getMessage():
+            msg = original_getMessage()
+            for pattern, replacement in self.SENSITIVE_PATTERNS:
+                msg = re.sub(pattern, replacement, msg)
+            return msg
+
+        record.getMessage = patched_getMessage
+        return True
+
+
+logging.getLogger("httpx").addFilter(_SensitiveDataFilter())

--- a/python/dataverse_sdk/constants.py
+++ b/python/dataverse_sdk/constants.py
@@ -12,10 +12,9 @@ class BaseEnumMeta(EnumMeta):
 
 
 class DataverseHost(str, Enum, metaclass=BaseEnumMeta):
-    DEV = "https://dev.visionai.linkervision.ai/dataverse/curation"
-    DEV2 = "https://dev2.visionai.linkervision.ai/dataverse/curation"
-    DEV3 = "https://dev3.visionai.linkervision.ai/dataverse/curation"
-    STAGING = "https://staging.visionai.linkervision.ai/dataverse/curation"
-    DEMO = "https://demo.visionai.linkervision.ai/dataverse/curation"
+    DEV = "https://dev.visionai.linkervision.com/dataverse/curation"
+    DEV2 = "https://dev2.visionai.linkervision.com/dataverse/curation"
+    DEV3 = "https://dev3.visionai.linkervision.com/dataverse/curation"
+    STAGING = "https://staging.visionai.linkervision.com/dataverse/curation"
     PRODUCTION = "https://visionai.linkervision.ai/dataverse/curation"
     LOCAL = "http://localhost:8000"


### PR DESCRIPTION

## Purpose

<!-- Briefly describe the purpose of this PR -->
...

<!-- Fill the task or bug ID in azure board AB#{ID} -->
- [AB#38051](https://dev.azure.com/linkerengineer/87361b6b-4b8a-4d65-8243-96cf1163a72f/_workitems/edit/38051)
- [AB#38170](https://dev.azure.com/linkerengineer/87361b6b-4b8a-4d65-8243-96cf1163a72f/_workitems/edit/38170)

## Root Cause

<!-- If the PR is bug fix, please provide the root cause of the bug -->
- When uploading files to S3 using presigned URLs, `httpx` logs the full request URL including AWS credentials.

## What Changes?

<!-- For new feature is what you add and how to use it, for the bug is how to fix it. -->
- As title.
- Update `DataverseHost` from `.ai` to `.com` except for `PRODUCTION`.

## What to Check?

- The filter intercepts logs and redacts sensitive parameters before they're displayed:
```
INFO:httpx:HTTP Request: PUT https://bucket.s3.amazonaws.com/file.txt?AWSAccessKeyId=***&Signature=***&Expires=***
```