### PR TITLE
feat: select convert artifact by `file_type` enum

### DIFF
--- a/python/dataverse_sdk/__init__.py
+++ b/python/dataverse_sdk/__init__.py
@@ -18,6 +18,7 @@ from .schemas.client import (
 from .schemas.common import (
     AnnotationFormat,
     AttributeType,
+    ConvertModelFileType,
     DatasetStatus,
     DatasetType,
     DataSource,
@@ -47,6 +48,7 @@ __all__ = [
     "DatasetStatus",
     "DataSource",
     "QuestionClass",
+    "ConvertModelFileType",
 ]
 
 

--- a/python/dataverse_sdk/apis/backend.py
+++ b/python/dataverse_sdk/apis/backend.py
@@ -12,6 +12,7 @@ from requests import sessions
 from requests.adapters import HTTPAdapter, Retry
 
 from ..exceptions.client import DataverseExceptionBase
+from ..schemas.common import ConvertModelFileType
 from ..utils.utils import chunks
 
 logger = logging.getLogger(__name__)
@@ -375,15 +376,12 @@ class BackendAPI:
         self,
         convert_record_id: int,
         timeout: int = 3000,
-        triton_format: bool = True,
-        raw_onnx: bool = False,
+        file_type: ConvertModelFileType = ConvertModelFileType.TRITON,
         permission: str = "",
         **kwargs,
     ) -> requests.models.Response:
         headers = self.headers.copy()
-        kwargs["triton"] = triton_format
-        if raw_onnx:
-            kwargs["raw_onnx"] = raw_onnx
+        kwargs["file_type"] = ConvertModelFileType(file_type).value
         if permission:
             headers["X-Request-Source"] = permission
         resp = self.send_request(

--- a/python/dataverse_sdk/client.py
+++ b/python/dataverse_sdk/client.py
@@ -49,7 +49,13 @@ from .schemas.client import (
     Sensor,
     UpdateQuestionClass,
 )
-from .schemas.common import AnnotationFormat, DatasetType, OntologyImageType, SensorType
+from .schemas.common import (
+    AnnotationFormat,
+    ConvertModelFileType,
+    DatasetType,
+    OntologyImageType,
+    SensorType,
+)
 from .utils.utils import (
     download_file_from_response,
     download_file_from_url,
@@ -1399,8 +1405,7 @@ of this project OR has been added before"
     def get_convert_model_file(
         convert_record_id: int,
         save_path: str = "./triton.zip",
-        triton_format: bool = True,
-        raw_onnx: bool = False,
+        file_type: ConvertModelFileType = ConvertModelFileType.TRITON,
         timeout: int = 3000,
         permission: str = "",
         client: Optional["DataverseClient"] = None,
@@ -1413,8 +1418,9 @@ of this project OR has been added before"
         convert_record_id : int
         save_path : str, optional
             local path for saving the model file, by default './triton.zip'
-        triton_format: bool, default=True
-        raw_onnx: bool, default=False
+        file_type: ConvertModelFileType, default=ConvertModelFileType.TRITON
+            which stored artifact to download: the triton bundle, the main model
+            artifact, the intermediate onnx, or the int8 calibration cache
         timeout : int, optional
             maximum timeout of the request, by default 3000
         client : Optional['DataverseClient'], optional
@@ -1433,8 +1439,7 @@ of this project OR has been added before"
         try:
             resp = api.get_convert_model_file(
                 convert_record_id=convert_record_id,
-                triton_format=triton_format,
-                raw_onnx=raw_onnx,
+                file_type=file_type,
                 timeout=timeout,
                 permission=permission,
             )

--- a/python/dataverse_sdk/schemas/client.py
+++ b/python/dataverse_sdk/schemas/client.py
@@ -7,6 +7,7 @@ from pydantic_core.core_schema import ValidationInfo
 from .common import (
     AnnotationFormat,
     AttributeType,
+    ConvertModelFileType,
     DatasetStatus,
     DatasetType,
     DataSource,
@@ -531,8 +532,7 @@ class ConvertRecord(BaseModel):
 
     def get_convert_model_file(
         self,
-        triton_format: bool = True,
-        raw_onnx: bool = False,
+        file_type: ConvertModelFileType = ConvertModelFileType.TRITON,
         save_path: str = "./triton.zip",
         timeout: int = 3000,
         permission: str = "",
@@ -542,8 +542,7 @@ class ConvertRecord(BaseModel):
         return DataverseClient.get_convert_model_file(
             convert_record_id=self.id,
             save_path=save_path,
-            triton_format=triton_format,
-            raw_onnx=raw_onnx,
+            file_type=file_type,
             timeout=timeout,
             permission=permission,
             client_alias=self.client_alias,

--- a/python/dataverse_sdk/schemas/common.py
+++ b/python/dataverse_sdk/schemas/common.py
@@ -64,6 +64,15 @@ class DataSource(str, Enum, metaclass=BaseEnumMeta):
     PRE_IMPORT = "pre_import"
 
 
+class ConvertModelFileType(str, Enum, metaclass=BaseEnumMeta):
+    """Which stored artifact of a convert record to download."""
+
+    TRITON = "triton"
+    MODEL = "model"
+    RAW_ONNX = "raw_onnx"
+    CALIB_CACHE = "calib_cache"
+
+
 @dataclass
 class SensorCounts:
     camera: int = 0

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "dataverse-sdk"
-PACKAGE_VERSION = "2.6.0"
+PACKAGE_VERSION = "2.7.0"
 DESC = "Dataverse SDK For Python"
 with open("README.md", encoding="utf-8") as fh:
     long_description = fh.read()


### PR DESCRIPTION


## Purpose

<!-- Briefly describe the purpose of this PR -->
Select convert artifact by `file_type` enum.

<!-- Fill the task or bug ID in azure board AB#{ID} -->
- [AB#43279](https://dev.azure.com/linkerengineer/87361b6b-4b8a-4d65-8243-96cf1163a72f/_workitems/edit/43279)

## BREAKING CHANGE

> [!WARNING]
> **Breaking:** `get_convert_model_file` dropped `triton`/`raw_onnx`. **Must switch to `file_type` after this**, and this PR should be merged after the PR in Curation merged.

## `DataverseClient.get_convert_model_file`
### Parameters

| Parameter | Type | Default | Description |
|---|---|---|---|
| `convert_record_id` | `int` | — (required) | Convert record to download from |
| `save_path` | `str` | `"./triton.zip"` | Local path to write the file |
| `file_type` | `ConvertModelFileType` | `TRITON` | Which artifact to download (see table below) |
| `timeout` | `int` | `3000` | Request timeout (seconds) |
| `permission` | `str` | `""` | Sets the `X-Request-Source` header; pass the caller's permission source if required |
| `client` | `DataverseClient` | `None` | Client instance; if omitted, `client_alias` must be given |
| `client_alias` | `str` | `None` | Registered client alias; required when `client` is `None` |

**`file_type` values**

| `file_type` | File downloaded | Available when |
|---|---|---|
| `triton` | Triton bundle (`.zip`) | always |
| `model` | Main artifact: `model.onnx` (`format=onnx`) or `trt.engine` (`format=trt`) | always |
| `raw_onnx` | Intermediate onnx (fp16: `trt.onnx`; D-FINE int8: fp32 `model.onnx`) | `format=trt` |
| `calib_cache` | `trt_int8_calib.cache` (int8 scale table) | D-FINE + int8 only |

### Return

`tuple[bool, str]` — `(success, save_path)`. `success=False` if the download failed.

### Example

```python
ok, path = DataverseClient.get_convert_model_file(
    convert_record_id=123,
    file_type=ConvertModelFileType.CALIB_CACHE,
    save_path="./calib.cache",
    client_alias="my-client",
)
```


