### PR TITLE
fix(python): send dataset fields production still requires

### DIFF
--- a/python/dataverse_sdk/apis/backend.py
+++ b/python/dataverse_sdk/apis/backend.py
@@ -428,10 +428,11 @@ class BackendAPI:
             "render_pcd": render_pcd,
             "description": description if description else "",
             "annotations": annotations if annotations else [],
-            "auto_tagging": [],  # FIXME: auto_tagging field is still required by production API.
+            "storage_url": "",  # FIXME: storage_url field is still required by production API.
+            "container_name": "",  # FIXME: container_name field is still required by production API.
+            "sas_token": "",  # FIXME: sas_token field is still required by production API.
         }
 
-        # Only send storage location fields when provided
         for key, value in (
             ("storage_url", storage_url),
             ("container_name", container_name),

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 AUTHOR = "LinkerVision"
 PACKAGE_NAME = "dataverse-sdk"
-PACKAGE_VERSION = "2.6.0"
+PACKAGE_VERSION = "2.6.1"
 DESC = "Dataverse SDK For Python"
 with open("README.md", encoding="utf-8") as fh:
     long_description = fh.read()


### PR DESCRIPTION
## Purpose


<!-- Fill the task or bug ID in azure board AB#{ID} -->
- [AB#43527](https://dev.azure.com/linkerengineer/87361b6b-4b8a-4d65-8243-96cf1163a72f/_workitems/edit/43527)

## Root Cause

- #79 removed the `sas_token` parameter and made the SDK skip `storage_url`/`container_name` when unset, but the production API still marks all three as required — so every `create_dataset` call against production fails with a 400 `field-error`.

## What Changes?

- Send `storage_url` / `container_name` / `sas_token` with `""` defaults (each marked `FIXME`); the existing loop still overwrites the first two with real values, so AWS/MinIO are unaffected. 
> [!NOTE]
> Deleting the three lines restores current behaviour once production makes them optional.
- Drop `auto_tagging`, which production no longer requires. Bump 2.6.0 → 2.6.1.

## What to Check?

Import a local dataset against **production** — this is what returned 400 before the fix:
```
python tools/import_dataset_from_local.py
  -host https://visionai.linkervision.com/dataverse/curation
  -e {your-account-email}
  -p {PASSWORD}
  -s {service-id}
  -project {project-id}
  --folder {/YOUR/TARGET/LOCAL/FOLDER}
  -name {dataset-name}
  -type annotated_data
  -anno vision_ai
```
